### PR TITLE
fix: use node name for OTLP endpoint

### DIFF
--- a/docs/onboarding/8_16/operator/values.yaml
+++ b/docs/onboarding/8_16/operator/values.yaml
@@ -516,8 +516,13 @@ collectors:
 instrumentation:
   name: elastic-instrumentation
   enabled: true
+  env:
+    - name: OTEL_K8S_NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
   exporter:
-    endpoint: http://opentelemetry-kube-stack-daemon-collector:4318
+    endpoint: http://$(OTEL_K8S_NODE_NAME):4318
   propagators:
     - tracecontext
     - baggage


### PR DESCRIPTION
As the OTLP running as a daemonset, the receiver's port are exposed at node level. Thus we can refer it directly in the deployed instrumentation. 

See another example: https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-kube-stack/examples/cloud-demo/values.yaml#L55

Differently than the example above, the OTEL_K8S_NODE_NAME environment variable notation is expanded using the Kubernetes nomenclature, thus relying on k8s for its expansion instead of the actual application.
