### PR TITLE
Onboarding readme - Added Installation pre requisites section

### DIFF
--- a/docs/onboarding/8_16/operator/README.md
+++ b/docs/onboarding/8_16/operator/README.md
@@ -52,6 +52,16 @@ where <LANGUAGE> is one of: `go` , `java`, `nodejs`, `python`, `dotnet`
 
 Depending on the deployment model (i.e. self-managed, ESS, serverless), different configuration will be needed.
 
+### Pre-requisites
+
+Before installing the operator follow these actions:
+
+1. Create an API Key
+
+2. Install the integration `Kubernetes OpenTelemetry Assets` in Kibana.
+
+3. Ensure you have `cluster-admin` privileges in your Kubernetes cluster.
+
 ### Installation
 
 All signals including logs, metrics, traces/APM go through the collector directly into Elasticsearch using the ES exporter, a collector's processor pipeline will be used to replace the APM server functionality.

--- a/docs/onboarding/8_16/operator/README.md
+++ b/docs/onboarding/8_16/operator/README.md
@@ -47,8 +47,7 @@ metadata:
 
 where <LANGUAGE> is one of: `go` , `java`, `nodejs`, `python`, `dotnet`
 
-
-## Configuration
+## Elastic Stack Configuration
 
 Depending on the deployment model (i.e. self-managed, ESS, serverless), different configuration will be needed.
 
@@ -56,13 +55,14 @@ Depending on the deployment model (i.e. self-managed, ESS, serverless), differen
 
 Before installing the operator follow these actions:
 
-1. Create an API Key
+1. Create an API Key.
 
-2. Install the integration `Kubernetes OpenTelemetry Assets` in Kibana.
+2. Install the following integrations in Kibana:
+  - `System`
+  - `Kubernetes`
+  - `Kubernetes OpenTelemetry Assets`
 
-3. Ensure you have `cluster-admin` privileges in your Kubernetes cluster.
-
-### Installation
+## Operator Installation
 
 All signals including logs, metrics, traces/APM go through the collector directly into Elasticsearch using the ES exporter, a collector's processor pipeline will be used to replace the APM server functionality.
 


### PR DESCRIPTION
Added pre-requisites section to identify that before installing the operator we should:
- Create an API Key (pending to determine the exact minimum permissions of the API Key)
- Install manually the required integrations in Kibana (system / kubernetes / kubernetes opentelemetry assets)