### PR TITLE
Add service.name field and drop_origin: true

### DIFF
--- a/docs/onboarding/8_16/operator/README.md
+++ b/docs/onboarding/8_16/operator/README.md
@@ -76,11 +76,6 @@ $ kubectl create namespace opentelemetry-operator-system
 ```
 $ helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
 $ helm repo update
-$ helm install --namespace opentelemetry-operator-system opentelemetry-kube-stack open-telemetry/opentelemetry-kube-stack --values ./resources/kubernetes/operator/helm/values.yaml --version 0.2.2
-```
-
-To upgrade an existing release to a new version of the chart:
-```
 $ helm upgrade --install --namespace opentelemetry-operator-system opentelemetry-kube-stack open-telemetry/opentelemetry-kube-stack --values ./resources/kubernetes/operator/helm/values.yaml --version 0.2.2
 ```
 

--- a/docs/onboarding/8_16/operator/README.md
+++ b/docs/onboarding/8_16/operator/README.md
@@ -76,6 +76,11 @@ $ kubectl create namespace opentelemetry-operator-system
 ```
 $ helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
 $ helm repo update
+$ helm install --namespace opentelemetry-operator-system opentelemetry-kube-stack open-telemetry/opentelemetry-kube-stack --values ./resources/kubernetes/operator/helm/values.yaml --version 0.2.2
+```
+
+To upgrade an existing release to a new version of the chart:
+```
 $ helm upgrade --install --namespace opentelemetry-operator-system opentelemetry-kube-stack open-telemetry/opentelemetry-kube-stack --values ./resources/kubernetes/operator/helm/values.yaml --version 0.2.2
 ```
 

--- a/docs/onboarding/8_16/operator/README.md
+++ b/docs/onboarding/8_16/operator/README.md
@@ -76,7 +76,7 @@ $ kubectl create namespace opentelemetry-operator-system
 ```
 $ helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
 $ helm repo update
-$ helm install --namespace opentelemetry-operator-system opentelemetry-kube-stack open-telemetry/opentelemetry-kube-stack --values ./resources/kubernetes/operator/helm/values.yaml --version 0.2.2
+$ helm upgrade --install --namespace opentelemetry-operator-system opentelemetry-kube-stack open-telemetry/opentelemetry-kube-stack --values ./resources/kubernetes/operator/helm/values.yaml --version 0.2.2
 ```
 
 ## Limitations

--- a/resources/kubernetes/operator/helm/values.yaml
+++ b/resources/kubernetes/operator/helm/values.yaml
@@ -120,7 +120,6 @@ collectors:
               - "k8s.pod.ip"
               - "k8s.pod.uid"
               - "k8s.pod.start_time"
-              - "k8s.container.name"
             labels:
               - tag_name: app.label.component
                 key: app.kubernetes.io/component
@@ -335,7 +334,6 @@ collectors:
               - "k8s.pod.ip"
               - "k8s.pod.uid"
               - "k8s.pod.start_time"
-              - "k8s.container.name"
             labels:
               - tag_name: app.label.component
                 key: app.kubernetes.io/component

--- a/resources/kubernetes/operator/helm/values.yaml
+++ b/resources/kubernetes/operator/helm/values.yaml
@@ -88,8 +88,8 @@ collectors:
             - key: service.name
               from_attribute: k8s.container.name
               action: insert
-            - tag_name: app.label.version
-              key: app.kubernetes.io/version
+            - key: service.version
+              from_attribute: app.label.version
               from: pod
         k8sattributes:
           passthrough: false

--- a/resources/kubernetes/operator/helm/values.yaml
+++ b/resources/kubernetes/operator/helm/values.yaml
@@ -88,9 +88,13 @@ collectors:
             - key: service.name
               from_attribute: k8s.container.name
               action: insert
+            - key: app.label.component
+              action: delete
             - key: service.version
               from_attribute: app.label.version
-              from: pod
+              action: insert
+            - key: app.label.version
+              action: delete
         k8sattributes:
           passthrough: false
           pod_association:
@@ -244,9 +248,13 @@ collectors:
             - key: service.name
               from_attribute: k8s.container.name
               action: insert
+            - key: app.label.component
+              action: delete
             - key: service.version
               from_attribute: app.label.version
               action: insert
+            - key: app.label.version
+              action: delete
         attributes/dataset:
           actions:
             - key: event.dataset

--- a/resources/kubernetes/operator/helm/values.yaml
+++ b/resources/kubernetes/operator/helm/values.yaml
@@ -85,6 +85,9 @@ collectors:
             - key: service.name
               from_attribute: app.label.component
               action: insert
+            - tag_name: app.label.version
+              key: app.kubernetes.io/version
+              from: pod
         k8sattributes:
           passthrough: false
           pod_association:
@@ -110,9 +113,16 @@ collectors:
               - "k8s.pod.ip"
               - "k8s.pod.uid"
               - "k8s.pod.start_time"
+              - "k8s.container.name"
             labels:
               - tag_name: app.label.component
                 key: app.kubernetes.io/component
+                from: pod
+              - key: service.name
+                from_attribute: k8s.container.name
+                action: insert
+              - tag_name: app.label.version
+                key: app.kubernetes.io/version
                 from: pod
       receivers:
         k8s_cluster:
@@ -205,6 +215,7 @@ collectors:
         elasticinframetrics:
           add_system_metrics: true
           add_k8s_metrics: true
+          drop_original: true
         resourcedetection/eks:
           detectors: [env, eks]
           timeout: 15s
@@ -229,6 +240,12 @@ collectors:
           attributes:
             - key: service.name
               from_attribute: app.label.component
+              action: insert
+            - key: service.name
+              from_attribute: k8s.container.name
+              action: insert
+            - key: service.version
+              from_attribute: app.label.version
               action: insert
         attributes/dataset:
           actions:
@@ -310,9 +327,13 @@ collectors:
               - "k8s.pod.ip"
               - "k8s.pod.uid"
               - "k8s.pod.start_time"
+              - "k8s.container.name"
             labels:
               - tag_name: app.label.component
                 key: app.kubernetes.io/component
+                from: pod
+              - tag_name: app.label.version
+                key: app.kubernetes.io/version
                 from: pod
       receivers:
         otlp:

--- a/resources/kubernetes/operator/helm/values.yaml
+++ b/resources/kubernetes/operator/helm/values.yaml
@@ -85,6 +85,9 @@ collectors:
             - key: service.name
               from_attribute: app.label.component
               action: insert
+            - key: service.name
+              from_attribute: k8s.container.name
+              action: insert
             - tag_name: app.label.version
               key: app.kubernetes.io/version
               from: pod
@@ -118,9 +121,6 @@ collectors:
               - tag_name: app.label.component
                 key: app.kubernetes.io/component
                 from: pod
-              - key: service.name
-                from_attribute: k8s.container.name
-                action: insert
               - tag_name: app.label.version
                 key: app.kubernetes.io/version
                 from: pod


### PR DESCRIPTION
In this PR:
1. Set service.name:

1.1. container with name: `prometheus-server` - has a service.name : `server` - that is set from pod labels:
```
kubectl describe pod prometheus-server-server-64ddbf6c85-r7tk5 | grep "Labels:" -a5
...
Labels:           app.kubernetes.io/component=server
                  app.kubernetes.io/instance=prometheus-server
                  app.kubernetes.io/managed-by=Helm
                  app.kubernetes.io/name=prometheus
                  app.kubernetes.io/part-of=prometheus
                  app.kubernetes.io/version=v2.54.1
```
<img width="2278" alt="Screenshot 2024-10-11 at 12 42 43" src="https://github.com/user-attachments/assets/7b4844e1-b27e-4bf0-a9f1-933a91b7b2f8">

1.2. rest of pods have k8s.container.name = service.name (screenshot above)

2. Set `service.version` based on `app.kubernetes.io/version` label (screenshot above)
3. remove redundant fields: `resource.attributes.app.label.component` and `resource.attributes.app.label.version`
4. Add drop_origin: true parameter for the `elasticinframetrics` processor
 