### PR TITLE
service.name: replace app.kubernetes.io/component to app.kubernetes.io/name

### DIFF
--- a/resources/kubernetes/operator/helm/values.yaml
+++ b/resources/kubernetes/operator/helm/values.yaml
@@ -83,12 +83,12 @@ collectors:
         resource/k8s:
           attributes:
             - key: service.name
-              from_attribute: app.label.component
+              from_attribute: app.label.name
               action: insert
             - key: service.name
               from_attribute: k8s.container.name
               action: insert
-            - key: app.label.component
+            - key: app.label.name
               action: delete
             - key: service.version
               from_attribute: app.label.version
@@ -121,8 +121,8 @@ collectors:
               - "k8s.pod.uid"
               - "k8s.pod.start_time"
             labels:
-              - tag_name: app.label.component
-                key: app.kubernetes.io/component
+              - tag_name: app.label.name
+                key: app.kubernetes.io/name
                 from: pod
               - tag_name: app.label.version
                 key: app.kubernetes.io/version
@@ -242,12 +242,12 @@ collectors:
         resource/k8s:
           attributes:
             - key: service.name
-              from_attribute: app.label.component
+              from_attribute: app.label.name
               action: insert
             - key: service.name
               from_attribute: k8s.container.name
               action: insert
-            - key: app.label.component
+            - key: app.label.name
               action: delete
             - key: service.version
               from_attribute: app.label.version
@@ -335,8 +335,8 @@ collectors:
               - "k8s.pod.uid"
               - "k8s.pod.start_time"
             labels:
-              - tag_name: app.label.component
-                key: app.kubernetes.io/component
+              - tag_name: app.label.name
+                key: app.kubernetes.io/name
                 from: pod
               - tag_name: app.label.version
                 key: app.kubernetes.io/version


### PR DESCRIPTION
container with name: `prometheus-server` - has a service.name : `prometheus` - that is set from pod label `app.kubernetes.io/name`:
```
kubectl describe pod prometheus-server-server-64ddbf6c85-r7tk5 | grep "Labels:" -a5
...
Labels:           app.kubernetes.io/component=server
                  app.kubernetes.io/instance=prometheus-server
                  app.kubernetes.io/managed-by=Helm
                  app.kubernetes.io/name=prometheus
                  app.kubernetes.io/part-of=prometheus
                  app.kubernetes.io/version=v2.54.1
```
<img width="2278" alt="Screenshot 2024-10-11 at 12 42 43" src="https://github.com/user-attachments/assets/5f48da86-50b1-43e4-82de-28a8b0cbebae">
