### PR TITLE
Updated Kubernetes onboarding README to be aligned with the onboarding UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ These pages detail the components and how to configure the EDOT Collector.
 - [Manual configurations](docs/manual-configuration.md): Manually configure the EDOT Collector to send data to Elastic Observability.
 - [Limitations](docs/collector-limitations.md): Understand the current limitations of the EDOT Collector.
 
+## Kubernetes Observability using the EDOT Collector
+
+- [Kubernetes guided onboarding](docs/onboarding/8_16/operator/README.md): Use the guided onboarding to send Kubernetes logs, metrics, and application traces to Elasticsearch using the EDOT Collector and [OpenTelemetry Operator]((https://github.com/open-telemetry/opentelemetry-operator/).
+
 ## Collect application data using the EDOT language SDKs
 
 Elastic offers several Distributions that extend [OpenTelemetry language SDKs](https://opentelemetry.io/docs/languages/). The following languages are currently available:

--- a/docs/onboarding/8_16/operator/README.md
+++ b/docs/onboarding/8_16/operator/README.md
@@ -33,7 +33,7 @@ This is the current list of supported versions:
 | Serverless    | 0.3.0              | values-0.3.0.yaml  |
 | 8.16.0        | 0.3.0              | values-0.3.0.yaml  |
 
-When installing the release, use the right `--version` and `-f values-x.y.z.yaml` parameters.
+When [installing the release](#manual-deployment-of-all-components), ensure you use the right `--version` and `-f values-x.y.z.yaml` parameters.
 (TBD: clarify the final naming of the values files)
 
 ## Components description

--- a/docs/onboarding/8_16/operator/README.md
+++ b/docs/onboarding/8_16/operator/README.md
@@ -14,7 +14,7 @@ This guide describes how to:
 - [Deploying components using Kibana Onboarding UX](#deploying-components-using-kibana-onboarding-ux)
 - [Manual deployment of all components](#manual-deployment-of-all-components)
 - [Installation verification](#installation-verification)
-- [Customizing installation](#customizing-installation)
+- [Instrumenting applications](#instrumenting-applications)
 - [Limitations](#limitations)
 
 ## Prerequisites
@@ -83,16 +83,6 @@ The Helm Chart is configured to enable zero-code instrumentation using the [Oper
 - Python
 - .NET
 
-To enable auto-instrumentation, add the corresponding annotation to the pods of existing deployments (`spec.template.metadata.annotations`), or to the desired namespace (to auto-instrument all pods in the namespace):
-
-```yaml
-metadata:
-  annotations:
-    instrumentation.opentelemetry.io/inject-<LANGUAGE>: "opentelemetry-operator-system/elastic-instrumentation"
-```
-
-where <LANGUAGE> is one of: `go` , `java`, `nodejs`, `python`, `dotnet`
-
 ## Deploying components using Kibana Onboarding UX
 
 The preferred method for deploying all components is through the Kibana Onboarding UX. Follow these steps:
@@ -147,15 +137,41 @@ $ helm repo update
 $ helm upgrade --install --namespace opentelemetry-operator-system opentelemetry-kube-stack open-telemetry/opentelemetry-kube-stack --values ./resources/kubernetes/operator/helm/values.yaml --version 0.3.0
 ```
 
-## Installation verification
+## Installation verification:
 
-Perform the following steps to verify that all components are healthy:
-(TBD)
+Regardless of the installation method followed, perform the following checks to verify that everything is running properly:
 
-## Customizing installation
+1. **Check Pods Status**
+   - Ensure the following components are running without errors:
+     - **Operator Pod**
+     - **DaemonSet Collector Pod**
+     - **Deployment Collector Pod**
 
-(TBD - share use cases that might require customization)
-If provided `values.yaml` is not valid you can update it and point it on `helm install` command.
+2. **Validate Instrumentation Object**
+   - Confirm that the **Instrumentation object** is deployed and configured with a valid **endpoint**.
+
+3. **Kibana Dashboard Check**
+   - Verify that the **[OTEL][Metrics Kubernetes] Cluster Overview** dashboard in **Kibana** is displaying data correctly.
+
+4. **Log Data Availability in Kibana**
+   - In **Kibana Discovery**, confirm the availability of data under the `__logs-*__` data view.
+
+5. **Metrics Data Availability in Kibana**
+   - In **Kibana Discovery**, ensure data is available under the `__metrics-*__` data view.
+
+## Instrumenting Applications
+
+To enable auto-instrumentation, add the corresponding annotation to the pods of existing deployments (`spec.template.metadata.annotations`), or to the desired namespace (to auto-instrument all pods in the namespace):
+
+```yaml
+metadata:
+  annotations:
+    instrumentation.opentelemetry.io/inject-<LANGUAGE>: "opentelemetry-operator-system/elastic-instrumentation"
+```
+
+where <LANGUAGE> is one of: `go` , `java`, `nodejs`, `python`, `dotnet`
+
+For detailed instructions and examples on how to instrument applications in Kubernetes using the OpenTelemetry Operator, refer to this guide (TBD-add link and document).
 
 ## Limitations
 

--- a/docs/onboarding/8_16/operator/README.md
+++ b/docs/onboarding/8_16/operator/README.md
@@ -43,7 +43,7 @@ When [installing the release](#manual-deployment-of-all-components), ensure you 
 The OpenTelemetry Operator is a [Kubernetes Operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/) implementation designed to manage OpenTelemetry resources in a Kubernetes environment. It defines and oversees the following Custom Resource Definitions (CRDs):
 
 - [OpenTelemetry Collectors](https://github.com/open-telemetry/opentelemetry-collector): Agents responsible for receiving, processing and exporting telemetry data such as logs, metrics, and traces.
-- [Instrumentation](https://opentelemetry.io/docs/concepts/instrumentation/automatic/): Used for the atomatic instrumentation of workloads by leveraging OpenTelemetry instrumentation libraries.
+- [Instrumentation](https://opentelemetry.io/docs/kubernetes/operator/automatic): Used for the atomatic instrumentation of workloads by leveraging OpenTelemetry instrumentation libraries.
 
 All signals including logs, metrics, traces are processed by the collectors and sent directly to Elasticsearch via the ES exporter. A collector's processor pipeline replaces the traditional APM server functionality for handling application traces.
 

--- a/docs/onboarding/8_16/operator/README.md
+++ b/docs/onboarding/8_16/operator/README.md
@@ -20,21 +20,21 @@ This guide describes how to:
 ## Prerequisites
 
 - Elastic Stack (self-managed or [Elastic Cloud](https://www.elastic.co/cloud)) version 8.16.0 or higher, or an [Elasticsearch serverless](https://www.elastic.co/docs/current/serverless/elasticsearch/get-started) project.
-- A Kubernetes version supported by the OpenTelemetry Operator (refer to the [compatibility matrix](https://github.com/open-telemetry/opentelemetry-operator?#compatibility-matrix) for more details).
+
+- A Kubernetes version supported by the OpenTelemetry Operator (refer to the operator's [compatibility matrix](https://github.com/open-telemetry/opentelemetry-operator?#compatibility-matrix) for more details).
 
 ## Compatibility Matrix
 
-The minimum supported version of the Elastic Stack for the OpenTelemetry based monitoring on Kubernetes is `8.16.0`. Different stack releases will support certain versions of the kube-stack Helm Chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-kube-stack).
+The minimum supported version of the Elastic Stack for OpenTelemetry-based monitoring on Kubernetes is `8.16.0`. Different Elastic Stack releases support specific versions of the [kube-stack Helm Chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-kube-stack).
 
-This is the current list of supported versions:
+The following is the current list of supported versions:
 
 | Stack Version | Helm Chart Version |    Values file     |
 |---------------|--------------------|--------------------|
-| Serverless    | 0.3.0              | values-0.3.0.yaml  |
-| 8.16.0        | 0.3.0              | values-0.3.0.yaml  |
+| Serverless    | 0.3.0              | values.yaml  |
+| 8.16.0        | 0.3.0              | values.yaml  |
 
-When [installing the release](#manual-deployment-of-all-components), ensure you use the right `--version` and `-f values-x.y.z.yaml` parameters.
-(TBD: clarify the final naming of the values files)
+When [installing the release](#manual-deployment-of-all-components), ensure you use the right `--version` and `-f <values-file>` parameters. Values files are available in the [resources directory](/resources/kubernetes/operator/helm).
 
 ## Components description
 

--- a/docs/onboarding/8_16/operator/README.md
+++ b/docs/onboarding/8_16/operator/README.md
@@ -19,8 +19,8 @@ This guide describes how to:
 
 ## Prerequisites
 
-- Elastic Stack in version 8.16.0 or higher (self-managed, ESS, or Serverless).
-- Kubernetes x.y (TBD)
+- Elastic Stack (self-managed or [Elastic Cloud](https://www.elastic.co/cloud)) version 8.16.0 or higher, or an [Elasticsearch serverless](https://www.elastic.co/docs/current/serverless/elasticsearch/get-started) project.
+- A Kubernetes version supported by the OpenTelemetry Operator (refer to the [compatibility matrix](https://github.com/open-telemetry/opentelemetry-operator?#compatibility-matrix) for more details).
 
 ## Compatibility Matrix
 
@@ -30,9 +30,11 @@ This is the current list of supported versions:
 
 | Stack Version | Helm Chart Version |    Values file     |
 |---------------|--------------------|--------------------|
-| 8.16.0        | 0.2.2              | values-0.2.2.yaml  |
+| Serverless    | 0.3.0              | values-0.3.0.yaml  |
+| 8.16.0        | 0.3.0              | values-0.3.0.yaml  |
 
 When installing the release, use the right `--version` and `-f values-x.y.z.yaml` parameters.
+(TBD: clarify the final naming of the values files)
 
 ## Components description
 

--- a/docs/onboarding/8_16/operator/README.md
+++ b/docs/onboarding/8_16/operator/README.md
@@ -52,6 +52,16 @@ where <LANGUAGE> is one of: `go` , `java`, `nodejs`, `python`, `dotnet`
 
 Depending on the deployment model (i.e. self-managed, ESS, serverless), different configuration will be needed.
 
+### Pre-requisites
+
+Before installing the operator follow these actions:
+
+1. Create an API Key
+
+2. Install the integration `Kubernetes OpenTelemetry Assets` in Kibana.
+
+3. Ensure you have `cluster-admin` privileges in your Kubernetes cluster.
+
 ### Installation
 
 All signals including logs, metrics, traces/APM go through the collector directly into Elasticsearch using the ES exporter, a collector's processor pipeline will be used to replace the APM server functionality.

--- a/docs/onboarding/8_16/operator/README.md
+++ b/docs/onboarding/8_16/operator/README.md
@@ -40,12 +40,12 @@ When [installing the release](#manual-deployment-of-all-components), ensure you 
 
 ### OpenTelemetry Operator
 
-The OpenTelemetry Operator is an implementation of a [Kubernetes Operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/). It defines and manages the following Custom Resource Definitions (CRDs)
+The OpenTelemetry Operator is a [Kubernetes Operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/) implementation designed to manage OpenTelemetry resources in a Kubernetes environment. It defines and oversees the following Custom Resource Definitions (CRDs):
 
-- [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector).
-- [Auto-instrumentation](https://opentelemetry.io/docs/concepts/instrumentation/automatic/) of the workloads using OpenTelemetry instrumentation libraries.
+- [OpenTelemetry Collectors](https://github.com/open-telemetry/opentelemetry-collector): Agents responsible for receiving, processing and exporting telemetry data such as logs, metrics, and traces.
+- [Instrumentation](https://opentelemetry.io/docs/concepts/instrumentation/automatic/): Used for the atomatic instrumentation of workloads by leveraging OpenTelemetry instrumentation libraries.
 
-All signals including logs, metrics, traces/APM go through the collectors directly into Elasticsearch using the ES exporter. A collector's processor pipeline will be used to replace the APM server functionality for application traces.
+All signals including logs, metrics, traces are processed by the collectors and sent directly to Elasticsearch via the ES exporter. A collector's processor pipeline replaces the traditional APM server functionality for handling application traces.
 
 ### Kube-stack Helm Chart
 

--- a/docs/onboarding/8_16/operator/README.md
+++ b/docs/onboarding/8_16/operator/README.md
@@ -47,8 +47,7 @@ metadata:
 
 where <LANGUAGE> is one of: `go` , `java`, `nodejs`, `python`, `dotnet`
 
-
-## Configuration
+## Elastic Stack Configuration
 
 Depending on the deployment model (i.e. self-managed, ESS, serverless), different configuration will be needed.
 
@@ -56,13 +55,14 @@ Depending on the deployment model (i.e. self-managed, ESS, serverless), differen
 
 Before installing the operator follow these actions:
 
-1. Create an API Key
+1. Create an API Key.
 
-2. Install the integration `Kubernetes OpenTelemetry Assets` in Kibana.
+2. Install the following integrations in Kibana:
+  - `System`
+  - `Kubernetes`
+  - `Kubernetes OpenTelemetry Assets`
 
-3. Ensure you have `cluster-admin` privileges in your Kubernetes cluster.
-
-### Installation
+## Operator Installation
 
 All signals including logs, metrics, traces/APM go through the collector directly into Elasticsearch using the ES exporter, a collector's processor pipeline will be used to replace the APM server functionality.
 

--- a/docs/onboarding/8_16/operator/README.md
+++ b/docs/onboarding/8_16/operator/README.md
@@ -43,7 +43,7 @@ When [installing the release](#manual-deployment-of-all-components), ensure you 
 The OpenTelemetry Operator is an implementation of a [Kubernetes Operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/). It defines and manages the following Custom Resource Definitions (CRDs)
 
 - [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector).
-- [auto-instrumentation](https://opentelemetry.io/docs/concepts/instrumentation/automatic/) of the workloads using OpenTelemetry instrumentation libraries.
+- [Auto-instrumentation](https://opentelemetry.io/docs/concepts/instrumentation/automatic/) of the workloads using OpenTelemetry instrumentation libraries.
 
 All signals including logs, metrics, traces/APM go through the collectors directly into Elasticsearch using the ES exporter. A collector's processor pipeline will be used to replace the APM server functionality for application traces.
 

--- a/docs/onboarding/8_16/operator/README.md
+++ b/docs/onboarding/8_16/operator/README.md
@@ -95,15 +95,15 @@ where <LANGUAGE> is one of: `go` , `java`, `nodejs`, `python`, `dotnet`
 
 ## Deploying components using Kibana Onboarding UX
 
-The recommended method for deploying all components is to usethe Kibana Onboarding UX. To do this:
+The preferred method for deploying all components is through the Kibana Onboarding UX. Follow these steps:
 
 1. Navigate in Kibana to **Observability** --> **Add data**
 2. Select **Kubernetes**, then choose **Kubernetes monitoring with EDOT Collector**.
 3. Follow the on-screen instructions to install the OpenTelemetry Operator using the Helm Chart and the provided `values.yaml`.
 
 Notes:
-- If the `elastic_endpoint` showed by the UI is not valid for your environment, replace it with the right Elasticsearch endpoint.
-- The displayed `elastic_api_key` belongs to an API key created automatically when the onboarding flow is opened.
+- If the `elastic_endpoint` showed by the UI is not valid for your environment, replace it with the correct Elasticsearch endpoint.
+- The displayed `elastic_api_key` corresponds to an API key that is automatically generated when the onboarding process is initiated.
 
 ## Manual deployment of all components
 
@@ -111,7 +111,8 @@ Notes:
 
 Before installing the operator follow these actions:
 
-1. Create an [API Key](https://www.elastic.co/guide/en/kibana/current/api-keys.html), and make note of its value (TBD: details of API key permissions).
+1. Create an [API Key](https://www.elastic.co/guide/en/kibana/current/api-keys.html), and make note of its value.
+(TBD: details of API key permissions).
 
 2. Install the following integrations in Kibana:
   - `System`
@@ -119,7 +120,7 @@ Before installing the operator follow these actions:
   - `Kubernetes OpenTelemetry Assets`
 
 Notes:
-- When `Kibana onboarding UX` is used, the previous actions are automatically performed by Kibana.
+- When using the [Kibana onboarding UX](#deploying-components-using-kibana-onboarding-ux), the previous actions are automatically handled by Kibana.
 
 ### Operator Installation
 

--- a/docs/onboarding/8_16/operator/README.md
+++ b/docs/onboarding/8_16/operator/README.md
@@ -11,6 +11,18 @@ This guide describes how to:
 - Elastic Stack in version 8.16.0 or higher (self-managed, ESS, or Serverless).
 - Kubernetes x.y (TBD)
 
+## Compatibility Matrix
+
+The minimum supported version of the Elastic Stack for the OpenTelemetry based monitoring on Kubernetes is `8.16.0`. Different stack releases will support certain versions of the kube-stack Helm Chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-kube-stack).
+
+This is the current list of supported versions:
+
+| Stack Version | Helm Chart Version |    Values file     |
+|---------------|--------------------|--------------------|
+| 8.16.0        | 0.2.2              | values-0.2.2.yaml  |
+
+When installing the release, use the right `--version` and `-f values-x.y.z.yaml` parameters.
+
 ## Components description
 
 ### OpenTelemetry Operator

--- a/docs/onboarding/8_16/operator/README.md
+++ b/docs/onboarding/8_16/operator/README.md
@@ -53,11 +53,11 @@ The [kube-stack Helm Chart](https://github.com/open-telemetry/opentelemetry-helm
 
 The chart is installed with a provided default `values.yaml` file that can be customized when needed.
 
-### Daemonset collectors
+### DaemonSet collectors
 
 The OpenTelemetry components deployed within the DaemonSet collectors are responsible for observing specific signals from each node. To ensure complete data collection, these components must be deployed on every node in the cluster. Failing to do so will result in partial and potentially incomplete data.
 
-The Daemonset collectors handle the following data:
+The DaemonSet collectors handle the following data:
 
 - Host Metrics: Collects host metrics (hostmetrics receiver) specific to each node.
 - Kubernetes Metrics: Captures metrics related to the Kubernetes infrastructure on each node.

--- a/docs/onboarding/8_16/operator/README.md
+++ b/docs/onboarding/8_16/operator/README.md
@@ -49,7 +49,7 @@ All signals including logs, metrics, traces are processed by the collectors and 
 
 ### Kube-stack Helm Chart
 
-The [kube-stack Helm Chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-kube-stack) will be utilized to manage the installation of the operator (including its CRDs) and configure a suite of collectors, which will instrument various Kubernetes components to enable comprehensive observability and monitoring.
+The [kube-stack Helm Chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-kube-stack) is used to manage the installation of the operator (including its CRDs) and to configure a suite of collectors, which instrument various Kubernetes components to enable comprehensive observability and monitoring.
 
 The chart is installed with a provided default `values.yaml` file that can be customized when needed.
 

--- a/docs/onboarding/8_16/operator/README.md
+++ b/docs/onboarding/8_16/operator/README.md
@@ -68,7 +68,7 @@ The DaemonSet collectors handle the following data:
 
 The OpenTelemetry components deployed within a Deployment collector focus on gathering data at the cluster level rather than at individual nodes. Unlike DaemonSet collectors, which need to be deployed on every node, a Deployment collector operates as a standalone instance.
 
-The deployment collector handles the following data:
+The Deployment collector handles the following data:
 
 - Kubernetes Events: Monitors and collects events occurring across the entire Kubernetes cluster.
 - Cluster Metrics: Captures metrics that provide insights into the overall health and performance of the Kubernetes cluster.

--- a/docs/onboarding/8_16/operator/README.md
+++ b/docs/onboarding/8_16/operator/README.md
@@ -6,6 +6,17 @@ This guide describes how to:
 - Use the EDOT Collector to send Kubernetes logs, metrics, and application traces to an Elasticsearch cluster.
 - Use the operator for applications [auto-instrumentation](https://opentelemetry.io/docs/kubernetes/operator/automatic/) in all supported languages.
 
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Compatibility Matrix](#compatibility-matrix)
+- [Components description](#components-description)
+- [Deploying components using Kibana Onboarding UX](#deploying-components-using-kibana-onboarding-ux)
+- [Manual deployment of all components](#manual-deployment-of-all-components)
+- [Installation verification](#installation-verification)
+- [Customizing installation](#customizing-installation)
+- [Limitations](#limitations)
+
 ## Prerequisites
 
 - Elastic Stack in version 8.16.0 or higher (self-managed, ESS, or Serverless).
@@ -92,7 +103,7 @@ Notes:
 - If the `elastic_endpoint` showed by the UI is not valid for your environment, replace it with the right Elasticsearch endpoint.
 - The displayed `elastic_api_key` belongs to an API key created automatically when the onboarding flow is opened.
 
-## Manual Deployment of all components
+## Manual deployment of all components
 
 ### Elastic Stack preparations
 

--- a/docs/onboarding/8_16/operator/README.md
+++ b/docs/onboarding/8_16/operator/README.md
@@ -1,19 +1,38 @@
-# Kubernetes Onboarding 8.16
+# Get started with OpenTelemetry for Kubernetes Observability
 
-This guide will help you get up and running with Kubernetes by walking through the setup and integration of key components, starting with the [OpenTelemetry Operator](https://github.com/open-telemetry/opentelemetry-operator/). The OpenTelemetry Operator is an implementation of a [Kubernetes Operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/).
+This guide describes how to:
 
-The operator manages:
+- Install the [OpenTelemetry Operator](https://github.com/open-telemetry/opentelemetry-operator/) using the [kube-stack Helm Chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-kube-stack).
+- Use the EDOT Collector to send Kubernetes logs, metrics, and application traces to an Elasticsearch cluster.
+- Use the operator for applications [auto-instrumentation](https://opentelemetry.io/docs/kubernetes/operator/automatic/) in all supported languages.
 
-- [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector)
-- [auto-instrumentation](https://opentelemetry.io/docs/concepts/instrumentation/automatic/) of the workloads using OpenTelemetry instrumentation libraries
+## Prerequisites
 
-## OpenTelemetry Operator
+- Elastic Stack in version 8.16.0 or higher (self-managed, ESS, or Serverless).
+- Kubernetes x.y (TBD)
 
-The [kube-stack Helm Chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-kube-stack) will be utilized to manage the installation of the Operator's Custom Resource Definitions (CRDs) alongside the configuration of a suite of collectors, which will instrument various components of the Kubernetes environment to enable comprehensive observability and monitoring.
+## Components description
+
+### OpenTelemetry Operator
+
+The OpenTelemetry Operator is an implementation of a [Kubernetes Operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/). It defines and manages the following Custom Resource Definitions (CRDs)
+
+- [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector).
+- [auto-instrumentation](https://opentelemetry.io/docs/concepts/instrumentation/automatic/) of the workloads using OpenTelemetry instrumentation libraries.
+
+All signals including logs, metrics, traces/APM go through the collectors directly into Elasticsearch using the ES exporter. A collector's processor pipeline will be used to replace the APM server functionality for application traces.
+
+### Kube-stack Helm Chart
+
+The [kube-stack Helm Chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-kube-stack) will be utilized to manage the installation of the operator (including its CRDs) and configure a suite of collectors, which will instrument various Kubernetes components to enable comprehensive observability and monitoring.
+
+The chart is installed with a provided default `values.yaml` file that can be customized when needed.
 
 ### Daemonset collectors
 
 The OpenTelemetry components deployed within the DaemonSet collectors are responsible for observing specific signals from each node. To ensure complete data collection, these components must be deployed on every node in the cluster. Failing to do so will result in partial and potentially incomplete data.
+
+The Daemonset collectors handle the following data:
 
 - Host Metrics: Collects host metrics (hostmetrics receiver) specific to each node.
 - Kubernetes Metrics: Captures metrics related to the Kubernetes infrastructure on each node.
@@ -23,6 +42,8 @@ The OpenTelemetry components deployed within the DaemonSet collectors are respon
 ### Deployment collector
 
 The OpenTelemetry components deployed within a Deployment collector focus on gathering data at the cluster level rather than at individual nodes. Unlike DaemonSet collectors, which need to be deployed on every node, a Deployment collector operates as a standalone instance.
+
+The deployment collector handles the following data:
 
 - Kubernetes Events: Monitors and collects events occurring across the entire Kubernetes cluster.
 - Cluster Metrics: Captures metrics that provide insights into the overall health and performance of the Kubernetes cluster.
@@ -37,7 +58,7 @@ The Helm Chart is configured to enable zero-code instrumentation using the [Oper
 - Python
 - .NET
 
-Auto-instrumentation is enabled by adding the corresponding annotation to the deployment (or namespace to auto-instrument all pods in the namespace)
+To enable auto-instrumentation, add the corresponding annotation to the pods of existing deployments (`spec.template.metadata.annotations`), or to the desired namespace (to auto-instrument all pods in the namespace):
 
 ```yaml
 metadata:
@@ -47,24 +68,35 @@ metadata:
 
 where <LANGUAGE> is one of: `go` , `java`, `nodejs`, `python`, `dotnet`
 
-## Elastic Stack Configuration
+## Deploying components using Kibana Onboarding UX
 
-Depending on the deployment model (i.e. self-managed, ESS, serverless), different configuration will be needed.
+The recommended way to deploy all the components is to follow the Kibana Onboarding UX. To do that:
 
-### Pre-requisites
+1. Go to Kibana --> **Observability** --> **Add data**
+2. Select **Kubernetes**, then **Kubernetes monitoring with EDOT Collector**.
+3. Follow the instructions within the page to install the OpenTelemetry Operator with the Helm Chart and the provided values.yaml.
+
+Notes:
+- If the `elastic_endpoint` showed by the UI is not valid for your environment, replace it with the right Elasticsearch endpoint.
+- The displayed `elastic_api_key` belongs to an API key created automatically when the onboarding flow is opened.
+
+## Manual Deployment of all components
+
+### Elastic Stack preparations
 
 Before installing the operator follow these actions:
 
-1. Create an API Key.
+1. Create an [API Key](https://www.elastic.co/guide/en/kibana/current/api-keys.html), and make note of its value (TBD: details of API key permissions).
 
 2. Install the following integrations in Kibana:
   - `System`
   - `Kubernetes`
   - `Kubernetes OpenTelemetry Assets`
 
-## Operator Installation
+Notes:
+- When `Kibana onboarding UX` is used, the previous actions are automatically performed by Kibana.
 
-All signals including logs, metrics, traces/APM go through the collector directly into Elasticsearch using the ES exporter, a collector's processor pipeline will be used to replace the APM server functionality.
+### Operator Installation
 
 1. Create the `opentelemetry-operator-system` Kubernetes namespace:
 ```
@@ -88,6 +120,16 @@ $ helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-he
 $ helm repo update
 $ helm install --namespace opentelemetry-operator-system opentelemetry-kube-stack open-telemetry/opentelemetry-kube-stack --values ./resources/kubernetes/operator/helm/values.yaml --version 0.2.2
 ```
+
+## Installation verification
+
+Perform the following steps to verify that all components are healthy:
+(TBD)
+
+## Customizing installation
+
+(TBD - share use cases that might require customization)
+If provided `values.yaml` is not valid you can update it and point it on `helm install` command.
 
 ## Limitations
 

--- a/docs/onboarding/8_16/operator/README.md
+++ b/docs/onboarding/8_16/operator/README.md
@@ -93,11 +93,11 @@ where <LANGUAGE> is one of: `go` , `java`, `nodejs`, `python`, `dotnet`
 
 ## Deploying components using Kibana Onboarding UX
 
-The recommended way to deploy all the components is to follow the Kibana Onboarding UX. To do that:
+The recommended method for deploying all components is to usethe Kibana Onboarding UX. To do this:
 
-1. Go to Kibana --> **Observability** --> **Add data**
-2. Select **Kubernetes**, then **Kubernetes monitoring with EDOT Collector**.
-3. Follow the instructions within the page to install the OpenTelemetry Operator with the Helm Chart and the provided values.yaml.
+1. Navigate in Kibana to **Observability** --> **Add data**
+2. Select **Kubernetes**, then choose **Kubernetes monitoring with EDOT Collector**.
+3. Follow the on-screen instructions to install the OpenTelemetry Operator using the Helm Chart and the provided `values.yaml`.
 
 Notes:
 - If the `elastic_endpoint` showed by the UI is not valid for your environment, replace it with the right Elasticsearch endpoint.


### PR DESCRIPTION
Summary of changes:

- Update in main readme to link to the Kubernetes onboarding doc.
- Changes in Kubernetes onboarding:
  - Changed the structure of the document
  - Added information about how to run everything using the Kibana new onboarding UX (cc: @akhileshpok )
  - Added pre-requisites section for manual deployment of the components.
  - Added "installation verification" section (pending to be filled).
  - Added compatibility matrix section