### PR TITLE
Updating override flag for resourcedetection processors

### DIFF
--- a/resources/kubernetes/operator/helm/values.yaml
+++ b/resources/kubernetes/operator/helm/values.yaml
@@ -71,11 +71,11 @@ collectors:
         resourcedetection/gcp:
           detectors: [env, gcp]
           timeout: 2s
-          override: false
+          override: true
         resourcedetection/aks:
           detectors: [env, aks]
           timeout: 2s
-          override: false
+          override: true
           aks:
             resource_attributes:
               k8s.cluster.name:


### PR DESCRIPTION
Aligning the override flag of resourcedetection processors. This is set to true in order to make the resourcedetection overidden.