### PR TITLE
Adding fix for host.name field update based on k8s.node.name

### DIFF
--- a/resources/kubernetes/operator/helm/values.yaml
+++ b/resources/kubernetes/operator/helm/values.yaml
@@ -95,6 +95,11 @@ collectors:
               action: insert
             - key: app.label.version
               action: delete
+        resource/hostname:
+          attributes:
+            - key: host.name
+              from_attribute: k8s.node.name
+              action: upsert
         k8sattributes:
           passthrough: false
           pod_association:
@@ -161,6 +166,7 @@ collectors:
             - resourcedetection/gcp
             - resourcedetection/aks
             - resource/k8s
+            - resource/hostname
             receivers:
             - k8s_cluster
           logs:
@@ -170,6 +176,7 @@ collectors:
             - resourcedetection/eks
             - resourcedetection/gcp
             - resourcedetection/aks
+            - resource/hostname
             exporters:
             - debug
             - elasticsearch/otel
@@ -504,6 +511,11 @@ collectors:
               action: insert
             - key: app.label.version
               action: delete
+        resource/hostname:
+          attributes:
+            - key: host.name
+              from_attribute: k8s.node.name
+              action: upsert
         attributes/dataset:
           actions:
             - key: event.dataset
@@ -727,6 +739,7 @@ collectors:
               - resourcedetection/gcp
               - resourcedetection/aks
               - resource/k8s
+              - resource/hostname
               - resource/cloud
             exporters:
               - debug
@@ -742,6 +755,7 @@ collectors:
               - resourcedetection/gcp
               - resourcedetection/aks
               - resource/k8s
+              - resource/hostname
               - resource/cloud
             exporters:
               - debug
@@ -759,6 +773,7 @@ collectors:
               - resourcedetection/gcp
               - resourcedetection/aks
               - resource/k8s
+              - resource/hostname
               - resource/cloud
               - attributes/dataset
               - resource/process
@@ -770,6 +785,7 @@ collectors:
               - otlp
             processors:
               - batch
+              - resource/hostname
             exporters:
               - debug
               - signaltometrics
@@ -779,6 +795,7 @@ collectors:
               - otlp
             processors:
               - batch
+              - resource/hostname
             exporters:
               - debug
               - signaltometrics
@@ -789,6 +806,7 @@ collectors:
             processors:
               - batch
               - elastictrace
+              - resource/hostname
             exporters:
               - debug
               - signaltometrics


### PR DESCRIPTION
Adds the needed `resource/hostname` processor that will update the `host.name` field based on k8s.node.name 

Before:
![379182423-1dfa46cd-a26d-45c4-b70d-6199e64ffa48](https://github.com/user-attachments/assets/9d2f713e-e315-46bb-8578-a3df0b7f5282)


After:
![Screenshot 2024-10-24 at 5 12 51 PM](https://github.com/user-attachments/assets/be83a632-8c15-4b5e-9e96-cd38386d8860)



# Relates: 

Closes: https://github.com/elastic/opentelemetry-dev/issues/516
Found in: https://github.com/elastic/opentelemetry-dev/issues/559