### PR TITLE
k8s-otel: cert-manager integration information added

### DIFF
--- a/docs/kubernetes/operator/README.md
+++ b/docs/kubernetes/operator/README.md
@@ -93,7 +93,7 @@ The preferred method for deploying all components is through Kibana Onboarding U
 2. Select **Kubernetes**, then choose **Kubernetes monitoring with EDOT Collector**.
 3. Follow the on-screen instructions to install the OpenTelemetry Operator using the Helm Chart and the provided `values.yaml`.
 
-Regarding the commands suggested by Kibana UI:
+Notes on installing the OpenTelemetry Operator:
 - If the `elastic_endpoint` showed by the UI is not valid for your environment, replace it with the correct Elasticsearch endpoint.
 - The displayed `elastic_api_key` corresponds to an API key created by Kibana when the onboarding process is initiated.
 

--- a/docs/kubernetes/operator/README.md
+++ b/docs/kubernetes/operator/README.md
@@ -94,7 +94,7 @@ The preferred method for deploying all components is through Kibana Onboarding U
 3. Follow the on-screen instructions to install the OpenTelemetry Operator using the Helm Chart and the provided `values.yaml`.
 
 Notes on installing the OpenTelemetry Operator:
-- If the `elastic_endpoint` showed by the UI is not valid for your environment, replace it with the correct Elasticsearch endpoint.
+- Make sure the `elastic_endpoint` shown in the installation command is valid for your environment. If not, replace it with the correct Elasticsearch endpoint.
 - The displayed `elastic_api_key` corresponds to an API key created by Kibana when the onboarding process is initiated.
 
 > [!NOTE]

--- a/docs/kubernetes/operator/README.md
+++ b/docs/kubernetes/operator/README.md
@@ -185,9 +185,9 @@ For troubleshooing details and verification steps, refer to [Troubleshooting aut
 
 ## Cert-manager integrated installation
 
-Integrating the operator with [cert-manager](https://cert-manager.io/) enables automatic generation and renewal of publicly trusted certificates. This section assumes that cert-manager and its CRDs are already installed in your Kubernetes environment. If it's not the case, refer to the [installation guide](https://cert-manager.io/docs/installation/) before continuing.
-
 In Kubernetes, in order for the API server to communicate with the webhook component (created by the operator), the webhook requires a TLS certificate that the API server is configured to trust. The default provided configuration sets the Helm Chart to auto generate the required certificate as a self-signed certificate with an expiration policy of 365 days. These certificates **won't be renewed** if the Helm Chart's release is not manually updated. For production environments, it is highly recommended to use a certificate manger like [cert-manager](https://cert-manager.io/docs/installation/).
+
+Integrating the operator with [cert-manager](https://cert-manager.io/) enables automatic generation and renewal of publicly trusted TLS certificates. This section assumes that cert-manager and its CRDs are already installed in your Kubernetes environment. If it's not the case, refer to the [cert-manager installation guide](https://cert-manager.io/docs/installation/) before continuing.
 
 In order to install the OpenTelemetry Operator Helm Chart integrated with `cert-manager` you have to set `admissionWebhooks.certManager.enabled` to true, and `autoGenerateCert.enabled` to false. This can be achieved in two different ways:
 

--- a/docs/kubernetes/operator/README.md
+++ b/docs/kubernetes/operator/README.md
@@ -213,7 +213,7 @@ helm upgrade --install --namespace opentelemetry-operator-system opentelemetry-k
               enabled: true  # Change from `false` to `true`
         ```
 
-      - **Remove auto-generated certificate settings.**
+      - **Remove the generation of a self-signed certificate**
 
         ```yaml
         # Remove the following lines:

--- a/docs/kubernetes/operator/README.md
+++ b/docs/kubernetes/operator/README.md
@@ -87,7 +87,7 @@ The Helm Chart is configured to enable zero-code instrumentation using the [Oper
 
 ## Deploy components using the guided onboarding
 
-The preferred method for deploying all components is through Kibana Onboarding UX. Follow these steps:
+The guided onboarding simplifies deploying your Kubernetes components by setting up an [API Key](https://www.elastic.co/guide/en/kibana/current/api-keys.html) and the needed [Integrations](https://www.elastic.co/docs/current/en/integrations) in the background. Follow these steps to use the guided onboarding:
 
 1. In Kibana, navigate to **Observability** → **Add data**.
 2. Select **Kubernetes**, then choose **Kubernetes monitoring with EDOT Collector**.

--- a/docs/kubernetes/operator/README.md
+++ b/docs/kubernetes/operator/README.md
@@ -23,7 +23,7 @@ This guide describes how to:
 
 - A Kubernetes version supported by the OpenTelemetry Operator (refer to the operator's [compatibility matrix](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/compatibility.md#compatibility-matrix) for more details).
 
-- If you opt for automatic certificates generation and renewal on the OpenTelemetry Operator, [cert-manager](https://cert-manager.io/docs/installation/) should be installed in the Kubernetes cluster. The operator default installation uses a self-signed certificate and **doesn't require** cert-manager to be installed.
+- If you opt for automatic certificate generation and renewal on the OpenTelemetry Operator, you need to install [cert-manager](https://cert-manager.io/docs/installation/) in the Kubernetes cluster. By default, the operator installation uses a self-signed certificate and **doesn't require** cert-manager.
 
 ## Compatibility Matrix
 

--- a/docs/kubernetes/operator/README.md
+++ b/docs/kubernetes/operator/README.md
@@ -95,7 +95,7 @@ The preferred method for deploying all components is through Kibana Onboarding U
 
 Notes on installing the OpenTelemetry Operator:
 - Make sure the `elastic_endpoint` shown in the installation command is valid for your environment. If not, replace it with the correct Elasticsearch endpoint.
-- The displayed `elastic_api_key` corresponds to an API key created by Kibana when the onboarding process is initiated.
+- The `elastic_api_key` shown in the installation command corresponds to an API key created by Kibana when the onboarding process is initiated.
 
 > [!NOTE]
 > The default installation deploys an OpenTelemetry Operator with a self-signed TLS certificate.

--- a/docs/kubernetes/operator/README.md
+++ b/docs/kubernetes/operator/README.md
@@ -45,7 +45,7 @@ When [installing the release](#manual-deployment-of-all-components), ensure you 
 The OpenTelemetry Operator is a [Kubernetes Operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/) implementation designed to manage OpenTelemetry resources in a Kubernetes environment. It defines and oversees the following Custom Resource Definitions (CRDs):
 
 - [OpenTelemetry Collectors](https://github.com/open-telemetry/opentelemetry-collector): Agents responsible for receiving, processing, and exporting telemetry data such as logs, metrics, and traces.
-- [Instrumentation](https://opentelemetry.io/docs/kubernetes/operator/automatic): Used for the automatic instrumentation of workloads by leveraging OpenTelemetry instrumentation libraries.
+- [Instrumentation](https://opentelemetry.io/docs/kubernetes/operator/automatic): Leverages OpenTelemetry instrumentation libraries to automatically instrument workloads.
 
 All signals including logs, metrics, traces are processed by the collectors and sent directly to Elasticsearch via the ES exporter. A collector's processor pipeline replaces the traditional APM server functionality for handling application traces.
 

--- a/docs/kubernetes/operator/README.md
+++ b/docs/kubernetes/operator/README.md
@@ -202,25 +202,25 @@ helm upgrade --install --namespace opentelemetry-operator-system opentelemetry-k
 
 * If you prefer to keep an updated copy of the `values.yaml` file:
 
-  1. **Download (or copy) and update** the `values.yaml` file with the following changes:
+  1. **Update** the `values.yaml` file with the following changes:
 
-    - **Enable cert-manager integration for admission webhooks.**
+      - **Enable cert-manager integration for admission webhooks.**
 
-      ```yaml
-      opentelemetry-operator:
-        admissionWebhooks:
-          certManager:
-            enabled: true  # Change from `false` to `true`
-      ```
+        ```yaml
+        opentelemetry-operator:
+          admissionWebhooks:
+            certManager:
+              enabled: true  # Change from `false` to `true`
+        ```
 
-    - **Remove auto-generated certificate settings.**
+      - **Remove auto-generated certificate settings.**
 
-      ```yaml
-      # Remove the following lines:
-      autoGenerateCert:
-        enabled: true
-        recreate: true
-      ```
+        ```yaml
+        # Remove the following lines:
+        autoGenerateCert:
+          enabled: true
+          recreate: true
+        ```
 
   2. Run the installation (or upgrade) command pointing to the updated file. For example, assuming that the updated file has been saved as `values_cert-manager.yaml`:
 

--- a/docs/kubernetes/operator/README.md
+++ b/docs/kubernetes/operator/README.md
@@ -179,7 +179,7 @@ where ``<LANGUAGE>`` is one of: `go` , `java`, `nodejs`, `python`, `dotnet`
 
 For detailed instructions and examples on how to instrument applications in Kubernetes using the OpenTelemetry Operator, refer to [Instrumenting applications](/docs/kubernetes/operator/instrumenting-applications.md).
 
-For troubleshooing details and verification steps, refer to [Troubleshooting auto-instrumentation](/docs/kubernetes/operator/troubleshoot-auto-instrumentation.md).
+For troubleshooting details and verification steps, refer to [Troubleshooting auto-instrumentation](/docs/kubernetes/operator/troubleshoot-auto-instrumentation.md).
 
 <!-- Do not change this anchor name as it's used by Kibana OTel+k8s Onboarding UX -->
 <a name="cert-manager"></a>

--- a/docs/kubernetes/operator/README.md
+++ b/docs/kubernetes/operator/README.md
@@ -89,7 +89,7 @@ The Helm Chart is configured to enable zero-code instrumentation using the [Oper
 
 The preferred method for deploying all components is through Kibana Onboarding UX. Follow these steps:
 
-1. Navigate in Kibana to **Observability** --> **Add data**
+1. In Kibana, navigate to **Observability** → **Add data**.
 2. Select **Kubernetes**, then choose **Kubernetes monitoring with EDOT Collector**.
 3. Follow the on-screen instructions to install the OpenTelemetry Operator using the Helm Chart and the provided `values.yaml`.
 

--- a/docs/kubernetes/operator/README.md
+++ b/docs/kubernetes/operator/README.md
@@ -213,7 +213,7 @@ helm upgrade --install --namespace opentelemetry-operator-system opentelemetry-k
               enabled: true  # Change from `false` to `true`
         ```
 
-      - **Remove the generation of a self-signed certificate**
+      - **Remove the generation of a self-signed certificate.**
 
         ```yaml
         # Remove the following lines:

--- a/docs/kubernetes/operator/README.md
+++ b/docs/kubernetes/operator/README.md
@@ -203,23 +203,23 @@ Option 2) If you prefer to keep an updated copy of the used `values.yaml`:
 
 - **Download (or copy) and update** the `values.yaml` file with the following changes:
 
-  - Enable cert-manager integration for admission webhooks:
+  - **Enable cert-manager integration for admission webhooks.**
 
-  ```yaml
-  opentelemetry-operator:
-    admissionWebhooks:
-      certManager:
-        enabled: true  # Change from `false` to `true`
-  ```
+    ```yaml
+    opentelemetry-operator:
+      admissionWebhooks:
+        certManager:
+          enabled: true  # Change from `false` to `true`
+    ```
 
-  - **Remove auto-generated certificate settings** if they’re no longer needed with cert-manager enabled:
+  - **Remove auto-generated certificate settings.**
 
-  ```yaml
-  # Remove the following lines:
-  autoGenerateCert:
-    enabled: true
-    recreate: true
-  ```
+    ```yaml
+    # Remove the following lines:
+    autoGenerateCert:
+      enabled: true
+      recreate: true
+    ```
 
 Afterwards just run the installation / upgrade command pointing to the updated file (assuming for example that the update file has been saved as `values_cert-manager.yaml`):
 

--- a/docs/kubernetes/operator/README.md
+++ b/docs/kubernetes/operator/README.md
@@ -192,7 +192,7 @@ Integrating the operator with [cert-manager](https://cert-manager.io/) enables a
 
 Follow any of the following options to install the OpenTelemetry Operator Helm Chart integrated with `cert-manager`:
 
-* Directly add these options to the installation command `--set opentelemetry-operator.admissionWebhooks.certManager.enabled=true --set opentelemetry-operator.autoGenerateCert=null`. For example:
+* Add `--set opentelemetry-operator.admissionWebhooks.certManager.enabled=true --set opentelemetry-operator.autoGenerateCert=null` to the installation command. For example:
 
 ```bash
 helm upgrade --install --namespace opentelemetry-operator-system opentelemetry-kube-stack open-telemetry/opentelemetry-kube-stack \

--- a/docs/kubernetes/operator/README.md
+++ b/docs/kubernetes/operator/README.md
@@ -186,7 +186,7 @@ For troubleshooing details and verification steps, refer to [Troubleshooting aut
 
 ## Cert-manager integrated installation
 
-In Kubernetes, in order for the API server to communicate with the webhook component (created by the operator), the webhook requires a TLS certificate that the API server is configured to trust. The default provided configuration sets the Helm Chart to auto generate the required certificate as a self-signed certificate with an expiration policy of 365 days. These certificates **won't be renewed** if the Helm Chart's release is not manually updated. For production environments, it is highly recommended to use a certificate manger like [cert-manager](https://cert-manager.io/docs/installation/).
+In Kubernetes, for the API server to communicate with the webhook component (created by the operator), the webhook requires a TLS certificate that the API server is configured to trust. The default provided configuration sets the Helm Chart to auto generate the required certificate as a self-signed certificate with an expiration policy of 365 days. These certificates **won't be renewed** if the Helm Chart's release is not manually updated. For production environments, we highly recommend using a certificate manager like [cert-manager](https://cert-manager.io/docs/installation/).
 
 Integrating the operator with [cert-manager](https://cert-manager.io/) enables automatic generation and renewal of publicly trusted TLS certificates. This section assumes that cert-manager and its CRDs are already installed in your Kubernetes environment. If that's not the case, refer to the [cert-manager installation guide](https://cert-manager.io/docs/installation/) before continuing.
 

--- a/docs/kubernetes/operator/README.md
+++ b/docs/kubernetes/operator/README.md
@@ -47,7 +47,7 @@ The OpenTelemetry Operator is a [Kubernetes Operator](https://kubernetes.io/docs
 - [OpenTelemetry Collectors](https://github.com/open-telemetry/opentelemetry-collector): Agents responsible for receiving, processing, and exporting telemetry data such as logs, metrics, and traces.
 - [Instrumentation](https://opentelemetry.io/docs/kubernetes/operator/automatic): Leverages OpenTelemetry instrumentation libraries to automatically instrument workloads.
 
-All signals including logs, metrics, traces are processed by the collectors and sent directly to Elasticsearch via the ES exporter. A collector's processor pipeline replaces the traditional APM server functionality for handling application traces.
+All signals including logs, metrics, and traces are processed by the collectors and sent directly to Elasticsearch using the ES exporter. A collector's processor pipeline replaces the traditional APM server functionality for handling application traces.
 
 ### Kube-stack Helm Chart
 

--- a/docs/kubernetes/operator/README.md
+++ b/docs/kubernetes/operator/README.md
@@ -85,7 +85,7 @@ The Helm Chart is configured to enable zero-code instrumentation using the [Oper
 - Python
 - .NET
 
-## Deploying components using Kibana Onboarding UX
+## Deploy components using the guided onboarding
 
 The preferred method for deploying all components is through Kibana Onboarding UX. Follow these steps:
 

--- a/docs/kubernetes/operator/README.md
+++ b/docs/kubernetes/operator/README.md
@@ -192,7 +192,7 @@ Integrating the operator with [cert-manager](https://cert-manager.io/) enables a
 
 Follow any of the following options to install the OpenTelemetry Operator Helm Chart integrated with `cert-manager`:
 
-* Directly adding to the installation command the options `--set opentelemetry-operator.admissionWebhooks.certManager.enabled=true --set opentelemetry-operator.autoGenerateCert=null`, like:
+* Directly add these options to the installation command `--set opentelemetry-operator.admissionWebhooks.certManager.enabled=true --set opentelemetry-operator.autoGenerateCert=null`. For example:
 
 ```bash
 helm upgrade --install --namespace opentelemetry-operator-system opentelemetry-kube-stack open-telemetry/opentelemetry-kube-stack \

--- a/docs/kubernetes/operator/README.md
+++ b/docs/kubernetes/operator/README.md
@@ -99,7 +99,7 @@ Notes on installing the OpenTelemetry Operator:
 
 > [!NOTE]
 > The default installation deploys an OpenTelemetry Operator with a self-signed TLS certificate.
-> If you prefer to use publicly trusted certificates with automatic generation and renewal functionality, refer to [cert-manager integrated installation](#cert-manager) for indications about how to customize the `values.yaml` file before running the `helm install` command.
+> To automatically generate and renew publicly trusted certificates, refer to [cert-manager integrated installation](#cert-manager) for instructions on customizing the `values.yaml` file before running the `helm install` command.
 
 ## Manual deployment of all components
 

--- a/docs/kubernetes/operator/README.md
+++ b/docs/kubernetes/operator/README.md
@@ -200,7 +200,7 @@ helm upgrade --install --namespace opentelemetry-operator-system opentelemetry-k
 --set opentelemetry-operator.admissionWebhooks.certManager.enabled=true --set opentelemetry-operator.admissionWebhooks.autoGenerateCert=null
 ```
 
-* If you prefer to keep an updated copy of the `values.yaml` file:
+* Keep an updated copy of the `values.yaml` file by following these steps:
 
   1. **Update** the `values.yaml` file with the following changes:
 

--- a/docs/kubernetes/operator/README.md
+++ b/docs/kubernetes/operator/README.md
@@ -44,7 +44,7 @@ When [installing the release](#manual-deployment-of-all-components), ensure you 
 
 The OpenTelemetry Operator is a [Kubernetes Operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/) implementation designed to manage OpenTelemetry resources in a Kubernetes environment. It defines and oversees the following Custom Resource Definitions (CRDs):
 
-- [OpenTelemetry Collectors](https://github.com/open-telemetry/opentelemetry-collector): Agents responsible for receiving, processing and exporting telemetry data such as logs, metrics, and traces.
+- [OpenTelemetry Collectors](https://github.com/open-telemetry/opentelemetry-collector): Agents responsible for receiving, processing, and exporting telemetry data such as logs, metrics, and traces.
 - [Instrumentation](https://opentelemetry.io/docs/kubernetes/operator/automatic): Used for the automatic instrumentation of workloads by leveraging OpenTelemetry instrumentation libraries.
 
 All signals including logs, metrics, traces are processed by the collectors and sent directly to Elasticsearch via the ES exporter. A collector's processor pipeline replaces the traditional APM server functionality for handling application traces.


### PR DESCRIPTION
Closes https://github.com/elastic/opentelemetry-dev/issues/568

I've added details about cert-manager integrated installations of the Otel Operator.

It will be also pointed by Kibana onboarding UX link added in https://github.com/elastic/kibana/issues/197620