### PR TITLE
fix: add filesystem mountinfo workaround

### DIFF
--- a/resources/kubernetes/operator/helm/values.yaml
+++ b/resources/kubernetes/operator/helm/values.yaml
@@ -225,6 +225,9 @@ collectors:
         cpu: 100m
         memory: 500Mi
     env:
+      # Work around for open /mounts error: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35990
+      - name: HOST_PROC_MOUNTINFO
+        value: ""
       - name: ELASTIC_AGENT_OTEL
         value: '"true"'
       - name: ELASTIC_ENDPOINT


### PR DESCRIPTION
Daemonset scraper error:

```
2024-10-31T15:27:12.613Z        error   scraperhelper/scrapercontroller.go:205  Error scraping metrics  {"kind": "receiver", "name": "hostmetrics", "data_type": "metrics", "error": "open /mounts: no such file or directory", "scraper": "hostmetrics"}
```

Additional context: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35990