### PR TITLE
split k8sattributes/ecs processor: do not add any extra metadata

### DIFF
--- a/resources/kubernetes/operator/helm/values.yaml
+++ b/resources/kubernetes/operator/helm/values.yaml
@@ -682,6 +682,21 @@ collectors:
               - tag_name: app.label.version
                 key: app.kubernetes.io/version
                 from: pod
+        k8sattributes/ecs:
+          filter:
+            # Only retrieve pods running on the same node as the collector
+            node_from_env_var: OTEL_K8S_NODE_NAME
+          passthrough: false
+          pod_association:
+            # Below association takes a look at the k8s.pod.ip and k8s.pod.uid resource attributes or connection's context, and tries to match it with the pod having the same attribute.
+            - sources:
+                - from: resource_attribute
+                  name: k8s.pod.ip
+            - sources:
+                - from: resource_attribute
+                  name: k8s.pod.uid
+            - sources:
+                - from: connection
       receivers:
         # [OTLP Receiver](https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/otlpreceiver)
         otlp:
@@ -852,7 +867,7 @@ collectors:
             processors:
               - elasticinframetrics
               - batch
-              - k8sattributes
+              - k8sattributes/ecs
               - resourcedetection/system
               - resourcedetection/eks
               - resourcedetection/gcp


### PR DESCRIPTION
What: create `k8sattributes/ecs` processor where not added extra metadata.

Why: with the common for otel and ecs `k8sattributes` processor all docs (in ecs mode) contained those fields:
```
k8s.daemonset.name
k8s.pod.ip
k8s.pod.start_time
k8s.replicaset.name
k8s.statefulset.name
```
those fields were not translated into the `kubernetes.*` field format (in opposite to fields like `deployment.name`, `namespace`, `node.name`, `pod.name` and `pod.uid` - that is defined here https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/57caf5f830369d3f4994f7563323c73d6842424a/exporter/elasticsearchexporter/model.go#L55-L59)

this PR is to prevent adding fields in `k8s.*` format in ecs mode docs and to prevent error related to the `k8s.pod.ip` field:
```
failed to index document	{"kind": "exporter", "data_type": "metrics", "name": "elasticsearch/ecs", "index": ".ds-metrics-kubernetes.pod-default-2024.11.04-000001", "error.type": "document_parsing_exception", "error.reason": "[1:699] failed to parse field [k8s.pod.ip] of type [ip] in a time series document at [2024-11-04T15:20:56.719Z]"}
``` 

Note: there still will be added `k8s.pod.start_time` attribute, because it [enabled by default](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.112.0/processor/k8sattributesprocessor/metadata.yaml#L33-L36)