### PR TITLE
autoGenerateCert indented within admissionWebhooks

### DIFF
--- a/resources/kubernetes/operator/helm/values.yaml
+++ b/resources/kubernetes/operator/helm/values.yaml
@@ -8,10 +8,9 @@ opentelemetry-operator:
     certManager:
       enabled: false # For production environments, it is [recommended to use cert-manager for better security and scalability](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-operator#tls-certificate-requirement).
 
-
-autoGenerateCert:
-  enabled: true # Enable/disable automatic certificate generation. Set to false if manually managing certificates.
-  recreate: true # Force certificate regeneration on updates. Only applicable if autoGenerateCert.enabled is true.
+    autoGenerateCert:
+      enabled: true # Enable/disable automatic certificate generation. Set to false if manually managing certificates.
+      recreate: true # Force certificate regeneration on updates. Only applicable if autoGenerateCert.enabled is true.
 
 crds:
   create: true # Install the OpenTelemetry Operator CRDs.


### PR DESCRIPTION
`autoGenerateCert` was incorrectly defined at root level. It should be inside `opentelemetry-operator.admissionWebhooks`.

It's a setting that belongs to the `opentelemetry-operator` chart (`kube-stack` dependency), and inside the chart it's defined inside `admissionWebhooks`:

https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-operator/values.yaml
