### PR TITLE
Helm update without checking

### DIFF
--- a/.github/workflows/operator-regression.yml
+++ b/.github/workflows/operator-regression.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           bash test/operator/match_and_execute.sh "kubectl create namespace opentelemetry-operator-system"
           bash test/operator/match_and_execute.sh "helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts"
-          bash test/operator/match_and_execute.sh "helm repo update"
+          helm repo update
           bash test/operator/match_and_execute.sh "helm upgrade --install --namespace opentelemetry-operator-system opentelemetry-kube-stack open-telemetry/opentelemetry-kube-stack --values ./resources/kubernetes/operator/helm/values.yaml --version 0.3.0"
           bash test/operator/wait_for_pod_start.sh opentelemetry-operator-system opentelemetry-operator 2/2 1
           kubectl get pods -A

--- a/.github/workflows/operator-regression.yml
+++ b/.github/workflows/operator-regression.yml
@@ -43,7 +43,7 @@ jobs:
           bash test/operator/match_and_execute.sh "kubectl create namespace opentelemetry-operator-system"
           bash test/operator/match_and_execute.sh "helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts"
           helm repo update
-          bash test/operator/match_and_execute.sh "helm upgrade --install --namespace opentelemetry-operator-system opentelemetry-kube-stack open-telemetry/opentelemetry-kube-stack --values ./resources/kubernetes/operator/helm/values.yaml --version 0.3.3"
+          bash test/operator/match_and_execute.sh "helm upgrade --install --namespace opentelemetry-operator-system opentelemetry-kube-stack open-telemetry/opentelemetry-kube-stack --values 'https://raw.githubusercontent.com/elastic/opentelemetry/refs/heads/8.16/resources/kubernetes/operator/helm/values.yaml' --version 0.3.3"
           bash test/operator/wait_for_pod_start.sh opentelemetry-operator-system opentelemetry-operator 2/2 1
           kubectl get pods -A
 

--- a/.github/workflows/operator-regression.yml
+++ b/.github/workflows/operator-regression.yml
@@ -43,7 +43,7 @@ jobs:
           bash test/operator/match_and_execute.sh "kubectl create namespace opentelemetry-operator-system"
           bash test/operator/match_and_execute.sh "helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts"
           helm repo update
-          bash test/operator/match_and_execute.sh "helm upgrade --install --namespace opentelemetry-operator-system opentelemetry-kube-stack open-telemetry/opentelemetry-kube-stack --values ./resources/kubernetes/operator/helm/values.yaml --version 0.3.0"
+          bash test/operator/match_and_execute.sh "helm upgrade --install --namespace opentelemetry-operator-system opentelemetry-kube-stack open-telemetry/opentelemetry-kube-stack --values ./resources/kubernetes/operator/helm/values.yaml --version 0.3.3"
           bash test/operator/wait_for_pod_start.sh opentelemetry-operator-system opentelemetry-operator 2/2 1
           kubectl get pods -A
 


### PR DESCRIPTION
update a couple of out-of-date diffs between README and test, and skip checking `helm repo update` (it's in the readme twice but test expects once), just do it without checking the readme has it, any check on helm says you should do that first anyway