### PR TITLE
K8s auto-instrumentation details and example (Node.js)

### DIFF
--- a/docs/kubernetes/operator/instrumenting-applications.md
+++ b/docs/kubernetes/operator/instrumenting-applications.md
@@ -170,13 +170,13 @@ Ensure that the `init container`, `volume`, and `environment variables` describe
 The OpenTelemetry Operator automates the process of instrumenting applications by injecting the necessary libraries and configuration into the application Pods.
 The process may vary slightly depending on the language, but it generally involves the following steps:
 
-- **Adding an init container**:
-
-  The operator adds an init container into the Pod. This container is responsible for copying the OpenTelemetry instrumentation library and make it accessible to the main application container.
-
 - **Creating a shared volume**:
 
-  The operator creates an `emptyDir` shared volume within the Pod, and mounts it in both containers. This volume serves as the medium for sharing the instrumentation library between the init container and the application container.
+  The operator declares an `emptyDir` shared volume within the Pod, and mounts it the app container and a new init container. This volume serves as the medium for sharing the instrumentation library between the new init container and the application container.
+
+- **Adding an init container**:
+
+  The operator adds an init container into the Pod. This container is responsible for copying the OpenTelemetry instrumentation library to the shared volume.
 
 - **Configuring the main container**:
 

--- a/docs/kubernetes/operator/instrumenting-applications.md
+++ b/docs/kubernetes/operator/instrumenting-applications.md
@@ -143,6 +143,7 @@ For details on instrumenting specific languages, refer to:
 
 - [Instrumenting Java](./instrumenting-java.md)
 - [Instrumenting Python](./instrumenting-python.md)
+- [Instrumenting Node.js](./instrumenting-nodejs.md)
 <!-- - [Instrumenting Dotnet](./instrumenting-dotnet.md) -->
 
 ### Namespace based annotations example

--- a/docs/kubernetes/operator/instrumenting-nodejs.md
+++ b/docs/kubernetes/operator/instrumenting-nodejs.md
@@ -1,0 +1,128 @@
+# Instrumenting Node.js applications with EDOT SDKs on Kubernetes
+
+This document focuses on instrumenting Node.js applications on Kubernetes, using the OpenTelemetry Operator, EDOT Collectors and the [EDOT Node.js](https://github.com/elastic/elastic-otel-node) SDK.
+
+For general knowledge about the EDOT Node.js SDK, refer to the [getting started guide](https://github.com/elastic/elastic-otel-node/blob/main/docs/get-started.md).
+
+For general information about instrumenting applications on kubernetes, refer to [instrumenting applications](./instrumenting-applications.md).
+
+(TBD / PENDING: extra topics or relevant details about Node.js specifics)
+
+## Guided example to instrument a Node.js app with EDOT Node.js SDK on Kubernetes
+
+In the following example you will learn how to:
+
+- Deploy an example Node.js app in a dedicated namespace.
+- Enable auto-instrumentation of the application following any of the supported methods, such as:
+  - Adding an annotation to the namespace.
+  - Adding an annotation to the deployment pods.
+- Verify that auto-instrumentation libraries are injected and configured correctly.
+- Confirm data is flowing to **Kibana Observability**.
+
+Before continuing, ensure you have performed the [installation of the operator](./README.md), and confirm that the following `Instrumentation` object exists in the system:
+
+```bash
+$ kubectl get instrumentation -n opentelemetry-operator-system
+NAME                      AGE    ENDPOINT                                                                                                
+elastic-instrumentation   107s   http://opentelemetry-kube-stack-daemon-collector.opentelemetry-operator-system.svc.cluster.local:4318
+```
+
+Example auto-instrumentation steps:
+
+1. Create a `nodejs` namespace and run a deployment named `nodejs-app`:
+
+(TBD / PENDING EXAMPLE)
+
+    ```bash
+    ```
+
+2. Enable auto-instrumentation of the Node.js application using one of the following methods:
+
+  - Add an annotation at namespace level:
+
+    ```bash
+    kubectl annotate namespace nodejs instrumentation.opentelemetry.io/inject-nodejs=opentelemetry-operator-system/elastic-instrumentation
+    ```
+
+  - Alternatively, edit the `nodejs-app` deployment to include the annotation under `spec.template.metadata.annotations`:
+
+    ```yaml
+    spec:
+    ...
+      template:
+        metadata:
+          labels:
+            app: nodejs-app
+          annotations:
+            instrumentation.opentelemetry.io/inject-nodejs: opentelemetry-operator-system/elastic-instrumentation
+    ...
+    ```
+
+3. Restart application
+
+    ```bash
+    kubectl rollout restart deployment nodejs-app -n nodejs
+    ```
+
+3. Verify the auto-instrumentation resources are injected in the Pod:
+
+<!-- FROM HERE WE HAVE TO REVIEW EVERYTHING
+
+  Node.js apps are instrumented by the OpenTelemetry Operator with the following actions:
+  (TBD - REVIEW)
+    - It adds an init container in the Pod with the objective of copying the SDK and making it available for the main container.
+    - Defines and mount an emptyDir volume 
+    - Configures the main container to use the SDK as a `java agent`.
+
+  Run `kubectl describe pod nodejs-app-xxxx` and check:
+
+  - There should be an init container named `opentelemetry-auto-instrumentation-nodejs` in the Pod:
+
+    ```bash
+    PENDING
+    ```
+
+  - The main container of the deployment is using the SDK (TBD)
+
+    ```bash
+PENDING
+    ```
+
+  - The Pod has an `EmptyDir` volume named `opentelemetry-auto-instrumentation-java` mounted in both the main and the init containers in path `/otel-auto-instrumentation-java`.
+
+    ```bash
+    Init Containers:
+      opentelemetry-auto-instrumentation-java:
+    ...
+        Mounts:
+          /otel-auto-instrumentation-java from opentelemetry-auto-instrumentation-java (rw)
+    Containers:
+      java-app:
+    ...  
+        Mounts:
+          /otel-auto-instrumentation-java from opentelemetry-auto-instrumentation-java (rw)
+    ...
+    Volumes:
+    ...
+      opentelemetry-auto-instrumentation-java:
+        Type:        EmptyDir (a temporary directory that shares a pod's lifetime)
+    ```
+
+  Ensure the environment variable `OTEL_EXPORTER_OTLP_ENDPOINT` points to a valid endpoint and there's network communication between the Pod and the endpoint.
+-->
+
+4. Confirm data is flowing through in **Kibana**:
+
+  - Open Observability -> Applications -> Service Inventory, and determine if:
+    - The application appears in the list of services.
+    - The application shows transactions and metrics.
+  
+  - For application logs, open **Kibana Discovery** and filter for your pods log, with any of:
+    - `k8s.deployment.name: "nodejs-app"`
+    - `k8s.pod.name: nodejs-app*`
+
+  Note that the application logs are not provided by the instrumentation library, but by the DaemonSet collector deployed as part of the [operator installation](./README.md)
+
+## Troubleshooting
+
+- Refer to [troubleshoot auto-instrumentation](./troubleshoot-auto-instrumentation.md) for further analysis.

--- a/docs/kubernetes/operator/instrumenting-nodejs.md
+++ b/docs/kubernetes/operator/instrumenting-nodejs.md
@@ -150,7 +150,7 @@ For this example, we assume the application you're instrumenting is a deployment
       - The application shows transactions and metrics.
 
       > [!TIP]
-      > Generate some traffic to your application to ensure there are transactions and metrics to see. You can use `kubectl port-forward` for this purpose is your application is not exposed externally.
+      > You may need to generate traffic to your application to see spans and metrics. Do this using `kubectl port-forward` if your application is not exposed externally.
 
     - For application container logs, open **Kibana Discover** and filter for your Pods' logs. In the provided example, we could filter for them with either of the following:
       - `k8s.deployment.name: "nodejs-app"` (**adapt the query filter to your use case**)

--- a/docs/kubernetes/operator/instrumenting-nodejs.md
+++ b/docs/kubernetes/operator/instrumenting-nodejs.md
@@ -67,7 +67,7 @@ For this example, we assume the application you're instrumenting is a deployment
     kubectl rollout restart deployment nodejs-app -n nodejs-ns
     ```
 
-4. Verify the [auto-instrumentation resources](./instrumenting-applications.md#how-auto-instrumentation-works) are injected in the Pod:
+4. Verify the [auto-instrumentation resources](./instrumenting-applications.md#how-auto-instrumentation-works) are injected in the Pods:
 
     Run a `kubectl describe` of one of your application Pods and check:
 
@@ -148,8 +148,6 @@ For this example, we assume the application you're instrumenting is a deployment
     - Open **Observability** -> **Applications** -> **Service inventory**, and determine if:
       - The application appears in the list of services (`nodejs-app` in the example).
       - The application shows transactions and metrics.
-
-
 
     - For application container logs, open **Kibana Discover** and filter for your Pods' logs. In the provided example, we could filter for them with either of the following:
       - `k8s.deployment.name: "nodejs-app"` (**adapt the query filter to your use case**)

--- a/docs/kubernetes/operator/instrumenting-nodejs.md
+++ b/docs/kubernetes/operator/instrumenting-nodejs.md
@@ -114,6 +114,8 @@ For this example, we assume the application you're instrumenting is a deployment
             OTEL_EXPORTER_OTLP_ENDPOINT:           http://opentelemetry-kube-stack-daemon-collector.opentelemetry-operator-system.svc.cluster.local:4318
       ...
       ```
+      
+      Ensure the environment variable `OTEL_EXPORTER_OTLP_ENDPOINT` points to a valid endpoint and there's network communication between the Pod and the endpoint.
 
     - The Pod has an `EmptyDir` volume named `opentelemetry-auto-instrumentation-nodejs` mounted in both the main and the init containers in path `/otel-auto-instrumentation-nodejs`.
 
@@ -134,8 +136,6 @@ For this example, we assume the application you're instrumenting is a deployment
         opentelemetry-auto-instrumentation-nodejs:
           Type:        EmptyDir (a temporary directory that shares a pod's lifetime)
       ```
-
-    Ensure the environment variable `OTEL_EXPORTER_OTLP_ENDPOINT` points to a valid endpoint and there's network communication between the Pod and the endpoint.
 
 5. Confirm data is flowing to **Kibana**:
 

--- a/docs/kubernetes/operator/instrumenting-nodejs.md
+++ b/docs/kubernetes/operator/instrumenting-nodejs.md
@@ -74,7 +74,7 @@ elastic-instrumentation   107s   http://opentelemetry-kube-stack-daemon-collecto
 
   - ??It adds an init container in the Pod with the objective of copying the SDK to a shared volume.
 
-  - ??efines an `emptyDir volume` mounted in both containers.
+  - ??Defines an `emptyDir volume` mounted in both containers.
 
   - ??Adds `NODE_OPTIONS` and other OTEL related environment variables.
 

--- a/docs/kubernetes/operator/instrumenting-nodejs.md
+++ b/docs/kubernetes/operator/instrumenting-nodejs.md
@@ -90,8 +90,9 @@ For this example, we assume the application you're instrumenting is a deployment
         Host Port:     <none>
         Command:
           cp
-          /nodejsagent.jar
-          /otel-auto-instrumentation-nodejs/nodejsagent.jar
+          -r
+          /autoinstrumentation/.
+          /otel-auto-instrumentation-nodejs
         State:          Terminated
           Reason:       Completed
           Exit Code:    0

--- a/docs/kubernetes/operator/instrumenting-nodejs.md
+++ b/docs/kubernetes/operator/instrumenting-nodejs.md
@@ -38,7 +38,7 @@ elastic-instrumentation   107s   http://opentelemetry-kube-stack-daemon-collecto
 
 2. Enable auto-instrumentation of the Node.js application using one of the following methods:
 
-  - Edit the `nodejs-app` workload definition and include the annotation under `spec.template.metadata.annotations`:
+  - Edit the workload definition and include the annotation under `spec.template.metadata.annotations`:
 
     ```yaml
     spec:

--- a/docs/kubernetes/operator/instrumenting-nodejs.md
+++ b/docs/kubernetes/operator/instrumenting-nodejs.md
@@ -1,14 +1,12 @@
 # Instrumenting Node.js applications with EDOT SDKs on Kubernetes
 
-This document focuses on instrumenting Node.js applications on Kubernetes, using [Elastic Distribution of OpenTelemetry Node.js (EDOT Node.js)](https://github.com/elastic/elastic-otel-nodejs) together with the OpenTelemetry Operator and the EDOT Collectors described in the [getting started](./README.md) guide.
+This document focuses on instrumenting Node.js applications on Kubernetes, using the OpenTelemetry Operator, the Elastic Distribution of OpenTelemetry (EDOT) Collectors, and the [EDOT Node.js](https://github.com/elastic/elastic-otel-nodejs) SDK.
 
-For general knowledge about the EDOT Node.js SDK, refer to the [getting started guide](https://github.com/elastic/elastic-otel-node/blob/main/packages/opentelemetry-node/docs/get-started.md) and [configuration](https://github.com/elastic/elastic-otel-node/blob/main/packages/opentelemetry-node/docs/configure.md).
+- For general knowledge about the EDOT Node.js SDK, refer to the [getting started guide](https://github.com/elastic/elastic-otel-node/blob/main/packages/opentelemetry-node/docs/get-started.md) and [configuration](https://github.com/elastic/elastic-otel-node/blob/main/packages/opentelemetry-node/docs/configure.md).
+- For Node.js auto-instrumentation specifics, refer to [OpenTelemetry Operator Node.js auto-instrumentation](https://opentelemetry.io/docs/kubernetes/operator/automatic/#nodejs).
+- For general information about instrumenting applications on kubernetes, refer to [instrumenting applications](./instrumenting-applications.md).
 
-For general information about instrumenting applications on kubernetes, refer to [instrumenting applications](./instrumenting-applications.md).
-
-(TBD / PENDING: extra topics or relevant details about Node.js specifics for Kubernetes, if any).
-
-## Guided example to instrument a Node.js app with EDOT Node.js SDK on Kubernetes
+## Instrument a Node.js app with EDOT Node.js SDK on Kubernetes
 
 <!--
 Useful links:
@@ -16,76 +14,146 @@ Useful links:
 (not user friendly, but we could use it in the future if we want to add a proper example here)
 -->
 
-In this section you will learn how to:
+In this example, you'll learn how to:
 
-- Enable auto-instrumentation of a Node.js application following any of the supported methods, such as:
-  - Adding an annotation to the deployment pods.
+- Enable auto-instrumentation of a Node.js application using one of the following supported methods:
+  - Adding an annotation to the deployment Pods.
   - Adding an annotation to the namespace.
 - Verify that auto-instrumentation libraries are injected and configured correctly.
 - Confirm data is flowing to **Kibana Observability**.
 
-For demonstration purposes, we assume the application to be instrumented is a deployment named `nodejs-app` running in the `nodejs-ns` namespace.
+For this example, we assume the application you're instrumenting is a deployment named `nodejs-app` running in the `nodejs-ns` namespace.
 
 1. Ensure you have successfully [installed the OpenTelemetry Operator](./README.md), and confirm that the following `Instrumentation` object exists in the system:
 
-```bash
-$ kubectl get instrumentation -n opentelemetry-operator-system
-NAME                      AGE    ENDPOINT                                                                                                
-elastic-instrumentation   107s   http://opentelemetry-kube-stack-daemon-collector.opentelemetry-operator-system.svc.cluster.local:4318
-```
-> [!NOTE]
-> If your `Instrumentation` object has a different name or is created in a different namespace, you will have to adapt the annotation value in the next step.
+    ```bash
+    $ kubectl get instrumentation -n opentelemetry-operator-system
+    NAME                      AGE    ENDPOINT
+    elastic-instrumentation   107s   http://opentelemetry-kube-stack-daemon-collector.opentelemetry-operator-system.svc.cluster.local:4318
+    ```
+    > [!NOTE]
+    > If your `Instrumentation` object has a different name or is created in a different namespace, you will have to adapt the annotation value in the next step.
 
-2. Enable auto-instrumentation of the Node.js application using one of the following methods:
+2. Enable auto-instrumentation of your Node.js application using one of the following methods:
 
-  - Edit the workload definition and include the annotation under `spec.template.metadata.annotations`:
+    - Edit your application workload definition and include the annotation under `spec.template.metadata.annotations`:
 
     ```yaml
+    kind: Deployment
+    metadata:
+      name: nodejs-app
+      namespace: nodejs-ns
     spec:
     ...
       template:
         metadata:
-          labels:
-            app: nodejs-app
+    ...
           annotations:
             instrumentation.opentelemetry.io/inject-nodejs: opentelemetry-operator-system/elastic-instrumentation
     ...
     ```
 
-  - Alternatively, add the annotation at namespace level to apply auto-instrumentation in all Pods of the namespace:
+    - Alternatively, add the annotation at namespace level to apply auto-instrumentation in all Pods of the namespace:
 
     ```bash
     kubectl annotate namespace nodejs-ns instrumentation.opentelemetry.io/inject-nodejs=opentelemetry-operator-system/elastic-instrumentation
     ```
 
-3. Restart application:
+3. Restart application
 
-  Once the annotation has been set, the Pods need to be recreated for the instrumentation libraries to be injected.
+    Once the annotation has been set, restart the application to create new Pods and inject the instrumentation libraries:
 
     ```bash
-    kubectl rollout restart deployment nodejs-app -n nodejs
+    kubectl rollout restart deployment nodejs-app -n nodejs-ns
     ```
 
-4. Verify the auto-instrumentation resources are injected in the Pod:
+4. Verify the [auto-instrumentation resources](./instrumenting-applications.md#how-auto-instrumentation-works) are injected in the Pod:
 
-  Node.js apps are instrumented by the OpenTelemetry Operator with the following actions:
-(TBD / WE NEED TO REVIEW HOW THIS IS DONE / NODE_OPTIONS env var?)
+    Run a `kubectl describe` of one of your application Pods and check:
 
-  - ??It adds an init container in the Pod with the objective of copying the SDK to a shared volume.
+**REVIEW NEEDED HERE, it's a copy & paste from java SDK used as javaagent**
 
-  - ??Defines an `emptyDir volume` mounted in both containers.
+    - There should be an init container named `opentelemetry-auto-instrumentation-nodejs` in the Pod:
 
-  - ??Adds `NODE_OPTIONS` and other OTEL related environment variables.
+    ```bash
+    $ kubectl describe pod nodejs-app-8d84c47b8-8h5z2 -n nodejs-ns
+    Name:             nodejs-app-8d84c47b8-8h5z2
+    Namespace:        nodejs-ns
+    ...
+    ...
+    Init Containers:
+      opentelemetry-auto-instrumentation-nodejs:
+        Container ID:  containerd://cbf67d7ca1bd62c25614b905a11e81405bed6fd215f2df21f84b90fd0279230b
+        Image:         docker.elastic.co/observability/elastic-otel-nodejs:1.0.0
+        Image ID:      docker.elastic.co/observability/elastic-otel-nodejs@sha256:28d65d04a329c8d5545ed579d6c17f0d74800b7b1c5875e75e0efd29e210566a
+        Port:          <none>
+        Host Port:     <none>
+        Command:
+          cp
+          /nodejsagent.jar
+          /otel-auto-instrumentation-nodejs/nodejsagent.jar
+        State:          Terminated
+          Reason:       Completed
+          Exit Code:    0
+          Started:      Wed, 13 Nov 2024 15:47:02 +0100
+          Finished:     Wed, 13 Nov 2024 15:47:03 +0100
+        Ready:          True
+        Restart Count:  0
+        Environment:    <none>
+        Mounts:
+          /otel-auto-instrumentation-nodejs from opentelemetry-auto-instrumentation-nodejs (rw)
+          /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-swhn5 (ro)
+    ```
 
-5. Confirm data is flowing through in **Kibana**:
+    - The main container of the deployment is using the SDK as `nodejsagent`:
 
-  - Open Observability -> Applications -> Service Inventory, and determine if:
-    - The application appears in the list of services.
-    - The application shows transactions and metrics.
-  
-  - For application container logs, open **Kibana Discover** and filter for your pods logs. In the provided example we could filter them with any of:
-    - `k8s.deployment.name: "nodejs-app"` (**adapt the query filter to your use case**)
-    - `k8s.pod.name: nodejs-app*` (**adapt the query filter to your use case**)
+    ```bash
+    ...
+    Containers:
+      nodejs-app:
+        Environment:
+    ...
+          JAVA_TOOL_OPTIONS:                      -nodejsagent:/otel-auto-instrumentation-nodejs/nodejsagent.jar
+          OTEL_SERVICE_NAME:                     nodejs-app
+          OTEL_EXPORTER_OTLP_ENDPOINT:           http://opentelemetry-kube-stack-daemon-collector.opentelemetry-operator-system.svc.cluster.local:4318
+    ...
+    ```
+
+    - The Pod has an `EmptyDir` volume named `opentelemetry-auto-instrumentation-nodejs` mounted in both the main and the init containers in path `/otel-auto-instrumentation-nodejs`.
+
+    ```bash
+    Init Containers:
+      opentelemetry-auto-instrumentation-nodejs:
+    ...
+        Mounts:
+          /otel-auto-instrumentation-nodejs from opentelemetry-auto-instrumentation-nodejs (rw)
+    Containers:
+      nodejs-app:
+    ...
+        Mounts:
+          /otel-auto-instrumentation-nodejs from opentelemetry-auto-instrumentation-nodejs (rw)
+    ...
+    Volumes:
+    ...
+      opentelemetry-auto-instrumentation-nodejs:
+        Type:        EmptyDir (a temporary directory that shares a pod's lifetime)
+    ```
+
+    Ensure the environment variable `OTEL_EXPORTER_OTLP_ENDPOINT` points to a valid endpoint and there's network communication between the Pod and the endpoint.
+
+**END OF REVIEW NEEDED SECTION**
+
+5. Confirm data is flowing to **Kibana**:
+
+    - Open **Observability** -> **Applications** -> **Service inventory**, and determine if:
+      - The application appears in the list of services (`nodejs-app` in the example).
+      - The application shows transactions and metrics.
+
+
+
+    - For application container logs, open **Kibana Discover** and filter for your Pods' logs. In the provided example, we could filter for them with either of the following:
+      - `k8s.deployment.name: "nodejs-app"` (**adapt the query filter to your use case**)
+      - `k8s.pod.name: nodejs-app*` (**adapt the query filter to your use case**)
 
     Note that the container logs are not provided by the instrumentation library, but by the DaemonSet collector deployed as part of the [operator installation](./README.md).
 

--- a/docs/kubernetes/operator/instrumenting-nodejs.md
+++ b/docs/kubernetes/operator/instrumenting-nodejs.md
@@ -73,7 +73,7 @@ For this example, we assume the application you're instrumenting is a deployment
 
 **REVIEW NEEDED HERE, it's a copy & paste from java SDK used as javaagent**
 
-    - There should be an init container named `opentelemetry-auto-instrumentation-nodejs` in the Pod:
+    - There should be an init container named `opentelemetry-auto-instrumentation-nodejs` in the Pod. For exapmle:
 
     ```bash
     $ kubectl describe pod nodejs-app-8d84c47b8-8h5z2 -n nodejs-ns

--- a/docs/kubernetes/operator/instrumenting-nodejs.md
+++ b/docs/kubernetes/operator/instrumenting-nodejs.md
@@ -149,6 +149,9 @@ For this example, we assume the application you're instrumenting is a deployment
       - The application appears in the list of services (`nodejs-app` in the example).
       - The application shows transactions and metrics.
 
+      > [!TIP]
+      > Generate some traffic to your application to ensure there are transactions and metrics to see. You can use `kubectl port-forward` for this purpose is your application is not exposed externally.
+
     - For application container logs, open **Kibana Discover** and filter for your Pods' logs. In the provided example, we could filter for them with either of the following:
       - `k8s.deployment.name: "nodejs-app"` (**adapt the query filter to your use case**)
       - `k8s.pod.name: nodejs-app*` (**adapt the query filter to your use case**)

--- a/docs/kubernetes/operator/instrumenting-nodejs.md
+++ b/docs/kubernetes/operator/instrumenting-nodejs.md
@@ -2,7 +2,7 @@
 
 This document focuses on instrumenting Node.js applications on Kubernetes, using the OpenTelemetry Operator, EDOT Collectors and the [EDOT Node.js](https://github.com/elastic/elastic-otel-node) SDK.
 
-For general knowledge about the EDOT Node.js SDK, refer to the [getting started guide](https://github.com/elastic/elastic-otel-node/blob/main/docs/get-started.md).
+For general knowledge about the EDOT Node.js SDK, refer to the [getting started guide](https://github.com/elastic/elastic-otel-node/blob/main/packages/opentelemetry-node/docs/get-started.md).
 
 For general information about instrumenting applications on kubernetes, refer to [instrumenting applications](./instrumenting-applications.md).
 

--- a/docs/kubernetes/operator/instrumenting-nodejs.md
+++ b/docs/kubernetes/operator/instrumenting-nodejs.md
@@ -114,7 +114,7 @@ For this example, we assume the application you're instrumenting is a deployment
       nodejs-app:
         Environment:
     ...
-          JAVA_TOOL_OPTIONS:                      -nodejsagent:/otel-auto-instrumentation-nodejs/nodejsagent.jar
+          NODE_OPTIONS:                           --require /otel-auto-instrumentation-nodejs/autoinstrumentation.js
           OTEL_SERVICE_NAME:                     nodejs-app
           OTEL_EXPORTER_OTLP_ENDPOINT:           http://opentelemetry-kube-stack-daemon-collector.opentelemetry-operator-system.svc.cluster.local:4318
     ...

--- a/docs/kubernetes/operator/instrumenting-nodejs.md
+++ b/docs/kubernetes/operator/instrumenting-nodejs.md
@@ -66,7 +66,7 @@ Example auto-instrumentation steps:
 
 3. Verify the auto-instrumentation resources are injected in the Pod:
 
-<!-- FROM HERE WE HAVE TO REVIEW EVERYTHING
+**FROM HERE ONWARDS WE HAVE TO REVIEW EVERYTHING**
 
   Node.js apps are instrumented by the OpenTelemetry Operator with the following actions:
   (TBD - REVIEW)
@@ -109,7 +109,6 @@ PENDING
     ```
 
   Ensure the environment variable `OTEL_EXPORTER_OTLP_ENDPOINT` points to a valid endpoint and there's network communication between the Pod and the endpoint.
--->
 
 4. Confirm data is flowing through in **Kibana**:
 

--- a/docs/kubernetes/operator/instrumenting-nodejs.md
+++ b/docs/kubernetes/operator/instrumenting-nodejs.md
@@ -7,7 +7,6 @@ For general knowledge about the EDOT Node.js SDK, refer to the [getting started 
 For general information about instrumenting applications on kubernetes, refer to [instrumenting applications](./instrumenting-applications.md).
 
 (TBD / PENDING: extra topics or relevant details about Node.js specifics for Kubernetes, if any).
-(TBD: for example... is there a way to deliver app logs via OTEL as we have in python?)
 
 ## Guided example to instrument a Node.js app with EDOT Node.js SDK on Kubernetes
 

--- a/docs/kubernetes/operator/instrumenting-nodejs.md
+++ b/docs/kubernetes/operator/instrumenting-nodejs.md
@@ -150,7 +150,7 @@ For this example, we assume the application you're instrumenting is a deployment
       - The application shows transactions and metrics.
 
       > [!TIP]
-      > You may need to generate traffic to your application to see spans and metrics. Do this using `kubectl port-forward` if your application is not exposed externally.
+      > You may need to generate traffic to your application to see spans and metrics. Do this using [`kubectl port-forward`](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_port-forward/) if your application is not exposed externally.
 
     - For application container logs, open **Kibana Discover** and filter for your Pods' logs. In the provided example, we could filter for them with either of the following:
       - `k8s.deployment.name: "nodejs-app"` (**adapt the query filter to your use case**)

--- a/docs/kubernetes/operator/instrumenting-nodejs.md
+++ b/docs/kubernetes/operator/instrumenting-nodejs.md
@@ -101,7 +101,7 @@ For this example, we assume the application you're instrumenting is a deployment
             /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-swhn5 (ro)
       ```
 
-    - The main container of the deployment is linking the SDK through `NODE_OPTIONS` environment variable:
+    - The main container of the deployment loads the SDK through the `NODE_OPTIONS` environment variable:
 
       ```bash
       ...

--- a/docs/kubernetes/operator/instrumenting-nodejs.md
+++ b/docs/kubernetes/operator/instrumenting-nodejs.md
@@ -144,7 +144,7 @@ For this example, we assume the application you're instrumenting is a deployment
       - The application shows transactions and metrics.
 
       > [!TIP]
-      > You may need to generate traffic to your application to see spans and metrics. Do this using [`kubectl port-forward`](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_port-forward/) if your application is not exposed externally.
+      > You may need to generate traffic to your application to see spans and metrics.
 
     - For application container logs, open **Kibana Discover** and filter for your Pods' logs. In the provided example, we could filter for them with either of the following:
       - `k8s.deployment.name: "nodejs-app"` (**adapt the query filter to your use case**)

--- a/docs/kubernetes/operator/instrumenting-nodejs.md
+++ b/docs/kubernetes/operator/instrumenting-nodejs.md
@@ -83,9 +83,6 @@ For this example, we assume the application you're instrumenting is a deployment
         opentelemetry-auto-instrumentation-nodejs:
           Container ID:  containerd://cbf67d7ca1bd62c25614b905a11e81405bed6fd215f2df21f84b90fd0279230b
           Image:         docker.elastic.co/observability/elastic-otel-node:0.5.0
-          Image ID:      docker.elastic.co/observability/elastic-otel-nodejs@sha256:ae6a699442ab33f661ed6aa1f38393f55a31038038ae194e1f9a858bc8df06ab
-          Port:          <none>
-          Host Port:     <none>
           Command:
             cp
             -r

--- a/docs/kubernetes/operator/instrumenting-nodejs.md
+++ b/docs/kubernetes/operator/instrumenting-nodejs.md
@@ -84,8 +84,8 @@ For this example, we assume the application you're instrumenting is a deployment
     Init Containers:
       opentelemetry-auto-instrumentation-nodejs:
         Container ID:  containerd://cbf67d7ca1bd62c25614b905a11e81405bed6fd215f2df21f84b90fd0279230b
-        Image:         docker.elastic.co/observability/elastic-otel-nodejs:1.0.0
-        Image ID:      docker.elastic.co/observability/elastic-otel-nodejs@sha256:28d65d04a329c8d5545ed579d6c17f0d74800b7b1c5875e75e0efd29e210566a
+        Image:         docker.elastic.co/observability/elastic-otel-node:0.5.0
+        Image ID:      docker.elastic.co/observability/elastic-otel-nodejs@sha256:ae6a699442ab33f661ed6aa1f38393f55a31038038ae194e1f9a858bc8df06ab
         Port:          <none>
         Host Port:     <none>
         Command:


### PR DESCRIPTION
Adding document `docs/kubernetes/operator/instrumenting-nodejs.md` with details for instrumenting Node.js applications on kubernetes with the EDOT Node.js and the operator.

@trentm , if possible I'd like your review on this:
- Check if we should add extra details to the file.
- I haven't described the details of how auto-instrumentation for Node.js is performed under the hood. (because I haven't tested it myself), but I think it's always useful as it helps with troubleshooting. Do you know how this is done? I assume it might be with an `init container to copy the SDK to a shared volume` plus a configuration in the main container to use the SDK through `NODE_OPTIONS` env var, but I'm not sure.

This PR is similar similar to:
https://github.com/elastic/opentelemetry/pull/54 (Java)
https://github.com/elastic/opentelemetry/pull/58 (Python)


