### PR TITLE
components description made collapsable in k8s otel operator main README.md

### DIFF
--- a/docs/kubernetes/operator/README.md
+++ b/docs/kubernetes/operator/README.md
@@ -3,7 +3,7 @@
 This guide describes how to:
 
 - Install the [OpenTelemetry Operator](https://github.com/open-telemetry/opentelemetry-operator/) using the [kube-stack Helm chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-kube-stack).
-- Use the EDOT Collector to send Kubernetes logs, metrics, and application traces to an Elasticsearch cluster.
+- Use the EDOT Collectors to send Kubernetes logs, metrics, and application traces to an Elasticsearch cluster.
 - Use the operator for applications [auto-instrumentation](https://opentelemetry.io/docs/kubernetes/operator/automatic/) in all supported languages.
 
 ## Table of Contents
@@ -41,6 +41,9 @@ The following is the current list of supported versions:
 When [installing the release](#manual-deployment-of-all-components), ensure you use the right `--version` and `-f <values-file>` parameters. Values files are available in the [resources directory](/resources/kubernetes/operator/helm).
 
 ## Components description
+
+<details>
+  <summary>Expand to see a detailed description of all components involved</summary>
 
 ### OpenTelemetry Operator
 
@@ -86,6 +89,8 @@ The Helm chart is configured to enable zero-code instrumentation using the [Oper
 - Node.js
 - Python
 - .NET
+
+</details>
 
 ## Deploy components using the guided onboarding
 
@@ -169,10 +174,10 @@ Regardless of the installation method followed, perform the following checks to 
    - Verify that the **[OTEL][Metrics Kubernetes] Cluster Overview** dashboard in **Kibana** is displaying data correctly.
 
 4. **Log Data Availability in Kibana**
-   - In **Kibana Discovery**, confirm the availability of data under the `__logs-*__` data view.
+   - In **Kibana Discover**, confirm the availability of data under the `__logs-*__` data view.
 
 5. **Metrics Data Availability in Kibana**
-   - In **Kibana Discovery**, ensure data is available under the `__metrics-*__` data view.
+   - In **Kibana Discover**, ensure data is available under the `__metrics-*__` data view.
 
 ## Instrumenting Applications
 

--- a/docs/kubernetes/operator/README.md
+++ b/docs/kubernetes/operator/README.md
@@ -42,8 +42,10 @@ When [installing the release](#manual-deployment-of-all-components), ensure you 
 
 ## Components description
 
+Getting started with OpenTelemetry for Kubernetes observability requires an understanding of the following components, their functions, and interactions: OpenTelemetry Operator, Collectors, kube-stack Helm Chart, and auto-instrumentation resources.
+
 <details>
-  <summary>Expand to see a detailed description of all components involved</summary>
+  <summary>Expand this section for a detailed description of these components.</summary>
 
 ### OpenTelemetry Operator
 
@@ -56,7 +58,7 @@ All signals including logs, metrics, and traces are processed by the collectors 
 
 ### Kube-stack Helm Chart
 
-The [kube-stack Helm chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-kube-stack) is used to manage the installation of the operator (including its CRDs) and to configure a suite of collectors, which instrument various Kubernetes components to enable comprehensive observability and monitoring.
+The [kube-stack Helm chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-kube-stack) is used to manage the installation of the operator (including its CRDs), and to configure a suite of collectors, which instrument various Kubernetes components to enable comprehensive observability and monitoring.
 
 The chart is installed with a provided default `values.yaml` file that can be customized when needed.
 


### PR DESCRIPTION
As stated in https://github.com/elastic/opentelemetry/issues/36 the main README for Kubernetes + OTEL Operator + EDOT is growing and feels a bit long.

After thinking of different options I have decided to only update the `components description` and instead of moving it to a different doc I have made it collapsable.

Let me know your thoughts on this: @rogercoll , @jackshirazi , @mdbirnstiehl 

I have decided to not separate the `customizing configuration` section because for the moment is quite short. if we add in the future a lot of configurable parameters to the table then we should definitely consider it.

We have multiple choices here:
- Apply this change and make the components description `collapsable`.
- Instead of making it collapsable, moving the content to another file (operator-components-description.md) and link it from the main doc.
- Go further and make other sections collapsable or moved to a different doc.

Closes https://github.com/elastic/opentelemetry/issues/36

