### PR TITLE
k8s operator doc tweaks

### DIFF
--- a/docs/kubernetes/operator/README.md
+++ b/docs/kubernetes/operator/README.md
@@ -120,9 +120,9 @@ Before installing the operator follow these actions:
 (TBD: details of API key permissions).
 
 2. Install the following integrations in Kibana:
-  - `System`
-  - `Kubernetes`
-  - `Kubernetes OpenTelemetry Assets`
+    - `System`
+    - `Kubernetes`
+    - `Kubernetes OpenTelemetry Assets`
 
 Notes:
 - When using the [Kibana onboarding UX](#deploying-components-using-kibana-onboarding-ux), the previous actions are automatically handled by Kibana.

--- a/docs/kubernetes/operator/instrumenting-applications.md
+++ b/docs/kubernetes/operator/instrumenting-applications.md
@@ -104,7 +104,7 @@ spec:
       containers:
       - image: myapplication-image
         name: app
-      ...        
+      ...
 ```
 
 where ``<LANGUAGE>`` is one of: `go` , `java`, `nodejs`, `python`, `dotnet`
@@ -130,7 +130,7 @@ After adding annotations to Pods or Namespaces, the applications must be restart
 kubectl rollout restart deployment/my-deployment
 ```
 
-In case you have multiple Instrumentation objects with different settings or images, ensure you point your Pods to the the desired `Instrumentation` objects in the annotations.
+In case you have multiple Instrumentation objects with different settings or images, ensure you point your Pods to the desired `Instrumentation` objects in the annotations.
 
 The possible values for the annotation are detailed in the [Operator documentation](https://opentelemetry.io/docs/kubernetes/operator/automatic/#add-annotations-to-existing-deployments). For reference purposes, the values are:
 
@@ -152,7 +152,7 @@ The following example creates a namespace with an annotation to instrument all P
 ```
 kubectl create namespace java-apps
 
-#Annotate app namespace
+# Annotate app namespace
 kubectl annotate namespace java-apps instrumentation.opentelemetry.io/inject-java="opentelemetry-operator-system/elastic-instrumentation"
 
 # Run a java example application in the namespace

--- a/docs/kubernetes/operator/instrumenting-java.md
+++ b/docs/kubernetes/operator/instrumenting-java.md
@@ -10,7 +10,7 @@ This document focuses on instrumenting Java applications on Kubernetes, using th
 
 The operator supports a configuration that installs [Java agent extensions](https://opentelemetry.io/docs/zero-code/java/agent/extensions/) in `Instrumentation` objects. The extension needs to be available in an image. Refer to [using extensions with the OpenTelemetry Java agent](https://www.elastic.co/observability-labs/blog/using-the-otel-operator-for-injecting-elastic-agents#using-an-extension-with-the-opentelemetry-java-agent) for an example of adding an extension to an agent.
 
-## Instrument a Java app with EDOT Java SDK on Kubernetes 
+## Instrument a Java app with EDOT Java SDK on Kubernetes
 
 In this example, you'll learn how to:
 
@@ -26,7 +26,7 @@ For this example, we assume the application you're instrumenting is a deployment
 
 ```bash
 $ kubectl get instrumentation -n opentelemetry-operator-system
-NAME                      AGE    ENDPOINT                                                                                                
+NAME                      AGE    ENDPOINT
 elastic-instrumentation   107s   http://opentelemetry-kube-stack-daemon-collector.opentelemetry-operator-system.svc.cluster.local:4318
 ```
 > [!NOTE]
@@ -62,7 +62,7 @@ elastic-instrumentation   107s   http://opentelemetry-kube-stack-daemon-collecto
   Once the annotation has been set, restart the application to create new Pods and inject the instrumentation libraries:
 
     ```bash
-    kubectl rollout restart deployment java-app -n java
+    kubectl rollout restart deployment java-app -n java-ns
     ```
 
 4. Verify the [auto-instrumentation resources](./instrumenting-applications.md#how-auto-instrumentation-works) are injected in the Pod:
@@ -72,7 +72,7 @@ elastic-instrumentation   107s   http://opentelemetry-kube-stack-daemon-collecto
   - There should be an init container named `opentelemetry-auto-instrumentation-java` in the Pod:
 
     ```bash
-    $ kubectl describe pod java-app-8d84c47b8-8h5z2 -n java
+    $ kubectl describe pod java-app-8d84c47b8-8h5z2 -n java-ns
     Name:             java-app-8d84c47b8-8h5z2
     Namespace:        java-ns
     ...
@@ -101,7 +101,7 @@ elastic-instrumentation   107s   http://opentelemetry-kube-stack-daemon-collecto
           /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-swhn5 (ro)
     ```
 
-  - The main container of the deployment is using the SDK as `javaagent`: 
+  - The main container of the deployment is using the SDK as `javaagent`:
 
     ```bash
     ...
@@ -125,7 +125,7 @@ elastic-instrumentation   107s   http://opentelemetry-kube-stack-daemon-collecto
           /otel-auto-instrumentation-java from opentelemetry-auto-instrumentation-java (rw)
     Containers:
       java-app:
-    ...  
+    ...
         Mounts:
           /otel-auto-instrumentation-java from opentelemetry-auto-instrumentation-java (rw)
     ...
@@ -142,7 +142,7 @@ elastic-instrumentation   107s   http://opentelemetry-kube-stack-daemon-collecto
   - Open **Observability** -> **Applications** -> **Service inventory**, and determine if:
     - The application appears in the list of services.
     - The application shows transactions and metrics.
-  
+
   - For application container logs, open **Kibana Discover** and filter for your Pods' logs. In the provided example, we could filter for them with either of the following:
     - `k8s.deployment.name: "java-app"` (**adapt the query filter to your use case**)
     - `k8s.pod.name: java-app*` (**adapt the query filter to your use case**)

--- a/docs/kubernetes/operator/instrumenting-python.md
+++ b/docs/kubernetes/operator/instrumenting-python.md
@@ -40,7 +40,7 @@ For this example, we assume the application you're instrumenting is a deployment
 
 ```bash
 $ kubectl get instrumentation -n opentelemetry-operator-system
-NAME                      AGE    ENDPOINT                                                                                                
+NAME                      AGE    ENDPOINT
 elastic-instrumentation   107s   http://opentelemetry-kube-stack-daemon-collector.opentelemetry-operator-system.svc.cluster.local:4318
 ```
 > [!NOTE]
@@ -73,7 +73,7 @@ elastic-instrumentation   107s   http://opentelemetry-kube-stack-daemon-collecto
   Once the annotation has been set, restart the application to create new Pods and inject the instrumentation libraries:
 
     ```bash
-    kubectl rollout restart deployment python-app -n python
+    kubectl rollout restart deployment python-app -n python-ns
     ```
 
 4. Verify the [auto-instrumentation resources](./instrumenting-applications.md#how-auto-instrumentation-works) are injected in the Pod:
@@ -83,7 +83,7 @@ elastic-instrumentation   107s   http://opentelemetry-kube-stack-daemon-collecto
   - There should be an init container named `opentelemetry-auto-instrumentation-python` in the Pod:
 
     ```bash
-    $ kubectl describe pod python-app-8d84c47b8-8h5z2 -n python
+    $ kubectl describe pod python-app-8d84c47b8-8h5z2 -n python-ns
     ...
     ...
     Init Containers:
@@ -131,7 +131,7 @@ elastic-instrumentation   107s   http://opentelemetry-kube-stack-daemon-collecto
           /otel-auto-instrumentation-python from opentelemetry-auto-instrumentation-python (rw)
     Containers:
       python-app:
-    ...  
+    ...
         Mounts:
           /otel-auto-instrumentation-python from opentelemetry-auto-instrumentation-python (rw)
     ...
@@ -143,15 +143,13 @@ elastic-instrumentation   107s   http://opentelemetry-kube-stack-daemon-collecto
 
   Ensure the environment variable `OTEL_EXPORTER_OTLP_ENDPOINT` points to a valid endpoint and there's network communication between the Pod and the endpoint.
 
-5. Confirm data is flowing through in **Kibana**:
-
 5. Confirm data is flowing to **Kibana**:
 
   - Open **Observability** -> **Applications** -> **Service inventory**, and determine if:
     - The application appears in the list of services.
     - The application shows transactions and metrics.
     - If [python logs instrumentation](https://opentelemetry.io/docs/kubernetes/operator/automatic/#auto-instrumenting-python-logs) is enabled, the application logs should  appear in the Logs tab.
-  
+
   - For application container logs, open **Kibana Discover** and filter for your Pods' logs. In the provided example, we could filter for them with either of the following:
     - `k8s.deployment.name: "python-app"` (**adapt the query filter to your use case**)
     - `k8s.pod.name: python-app*` (**adapt the query filter to your use case**)


### PR DESCRIPTION
@eedugon Some minor tweaks to the k8s operator docs that I noticed while reviewing https://github.com/elastic/opentelemetry/pull/59

- Correction (I think) to the namespace used in some kubectl commands in the Java and Python docs
- Unfortunately my editor removes trailing whitespace and there were some in these docs, so the diff will be smaller if you hide whitespace differences.
- Remove a duplicate header in the python doc.