### PR TITLE
Fix wrong doc links in Get Started docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ Regardless of the source, all telemetry flows through the EDOT Collector, where 
 
 | **Use Case**                 | **Telemetry Type**         | **Infrastructure**        | <div align="center">**EDOT Collector**</div> | <div align="center">**EDOT SDK**</div> | <div align="center">**Setup EDOT**</div> |
 |------------------------------|---------------------------|---------------------------|:----------------------------------:|:----------------------------------:|----------------------|
-| **Applications & Infrastructure** | Logs, Metrics, Traces | Kubernetes                 | ✅ | ✅ | [Quickstart](https://github.com/elastic/opentelemetry/blob/miguel-docs/quickstart-guide.md#%EF%B8%8F-kubernetes---infrastructure--application--monitoring)|
-| **Infrastructure Only**      | Logs, Metrics            | Kubernetes                 | ✅ | ❌ | [Quickstart](https://github.com/elastic/opentelemetry/blob/miguel-docs/quickstart-guide.md#%EF%B8%8F-kubernetes---infrastructure--application--monitoring)|
-| **Hosts**      | Logs, Metrics            | Host (VM, Bare Metal)      | ✅ | ❌ | [Quickstart](https://github.com/elastic/opentelemetry/blob/miguel-docs/quickstart-guide.md#%EF%B8%8F-hosts-monitoring-and-log-collection) |
+| **Applications & Infrastructure** | Logs, Metrics, Traces | Kubernetes                 | ✅ | ✅ | [Quickstart](https://github.com/elastic/opentelemetry/blob/main/quickstart-guide.md#%EF%B8%8F-kubernetes---infrastructure--application--monitoring)|
+| **Infrastructure Only**      | Logs, Metrics            | Kubernetes                 | ✅ | ❌ | [Quickstart](https://github.com/elastic/opentelemetry/blob/main/quickstart-guide.md#%EF%B8%8F-kubernetes---infrastructure--application--monitoring)|
+| **Hosts**      | Logs, Metrics            | Host (VM, Bare Metal)      | ✅ | ❌ | [Quickstart](https://github.com/elastic/opentelemetry/blob/main/quickstart-guide.md#%EF%B8%8F-hosts-monitoring-and-log-collection) |
 
 ### 📥 Report issues or provide feedback
 To report issues or provide feedback on EDOT, please [submit a github issue](https://github.com/elastic/opentelemetry/issues/new/choose).


### PR DESCRIPTION
The docs were pointing to the branch from miguel to pages that do not exist anymore. The links should point to main.