### PR TITLE
fix broken section for dotnet

### DIFF
--- a/docs/_edot-sdks/dotnet/setup/index.md
+++ b/docs/_edot-sdks/dotnet/setup/index.md
@@ -2,10 +2,10 @@
 title: Setup
 layout: default
 nav_order: 1
-parent: EDOT Java
+parent: EDOT .NET
 ---
 
-# Setting up the EDOT Java Agent
+# Setting up the EDOT .NET Agent
 
 TODO:
 - where to download


### PR DESCRIPTION
copy-paste error that is visible in the left menu in the java section:

![image](https://github.com/user-attachments/assets/561f692a-0ebc-4337-932d-e2c072a041e1)
