### PR TITLE
semconv 1.27.0 rename: deployment.environment{,.name}

### DIFF
--- a/docs/_edot-sdks/java/migration.md
+++ b/docs/_edot-sdks/java/migration.md
@@ -93,9 +93,9 @@ For example: `OTEL_RESOURCE_ATTRIBUTES=service.version=1.2.3`.
 
 ### `environment`
 
-The Elastic [`environment`](https://www.elastic.co/guide/en/apm/agent/java/current/config-core.html#config-environment) option corresponds to setting the `deployment.environment` key in [OTEL_RESOURCE_ATTRIBUTES](https://opentelemetry.io/docs/concepts/sdk-configuration/general-sdk-configuration/#otel_resource_attributes).
+The Elastic [`environment`](https://www.elastic.co/guide/en/apm/agent/java/current/config-core.html#config-environment) option corresponds to setting the `deployment.environment.name` key in [OTEL_RESOURCE_ATTRIBUTES](https://opentelemetry.io/docs/concepts/sdk-configuration/general-sdk-configuration/#otel_resource_attributes).
 
-For example: `OTEL_RESOURCE_ATTRIBUTES=deployment.environment=testing`.
+For example: `OTEL_RESOURCE_ATTRIBUTES=deployment.environment.name=testing`.
 
 ### `global_labels`
 


### PR DESCRIPTION
The `deployment.environment` resource attribute has been renamed `deployment.environment.name` in [semconv 1.27.0](https://github.com/open-telemetry/semantic-conventions/releases/tag/v1.27.0)