### PR TITLE
fix + reformat linux/macos collector commands

### DIFF
--- a/docs/quickstart/self-managed/hosts_vms.md
+++ b/docs/quickstart/self-managed/hosts_vms.md
@@ -26,17 +26,25 @@ The quick start for Hosts / VMs with a self-managed Elastic Stack will guide you
     *Linux*
 
     ```bash
-    ELASTICSEARCH_ENDPOINT=<ELASTICSEARCH_ENDPOINT> \
-    ELASTIC_API_KEY=<ELASTIC_API_KEY> \
-    rm ./otel.yml && cp ./otel_samples/logs_metrics_traces.yml ./otel.yml && mkdir -p ./data/otelcol && sed -i 's#\${env:STORAGE_DIR}#'"$PWD"/data/otelcol'#g' ./otel.yml && sed -i 's#\${env:ELASTIC_ENDPOINT}#$ELASTICSEARCH_ENDPOINT' ./otel.yml && sed -i 's/\${env:ELASTIC_API_KEY}/$ELASTIC_API_KEY/g' ./otel.yml
+    ELASTICSEARCH_ENDPOINT=<ELASTICSEARCH_ENDPOINT> && \
+    ELASTIC_API_KEY=<ELASTIC_API_KEY> && \
+    cp ./otel_samples/logs_metrics_traces.yml ./otel.yml && \
+    mkdir -p ./data/otelcol && \
+    sed -i "s#\${env:STORAGE_DIR}#${PWD}/data/otelcol#g" ./otel.yml && \
+    sed -i "s#\${env:ELASTIC_ENDPOINT}#${ELASTICSEARCH_ENDPOINT}#g" ./otel.yml && \
+    sed -i "s#\${env:ELASTIC_API_KEY}#$ELASTIC_API_KEY#g" ./otel.yml
     ```
 
     *MacOS*
 
     ```bash
-    ELASTICSEARCH_ENDPOINT=<ELASTICSEARCH_ENDPOINT> \
-    ELASTIC_API_KEY=<ELASTIC_API_KEY> \
-    rm ./otel.yml && cp ./otel_samples/logs_metrics_traces.yml ./otel.yml && mkdir -p ./data/otelcol && sed -i '' 's#\${env:STORAGE_DIR}#'"$PWD"/data/otelcol'#g' ./otel.yml && sed -i '' 's#\${env:ELASTIC_ENDPOINT}#'"$ELASTICSEARCH_ENDPOINT"'#g' ./otel.yml && sed -i '' 's#\${env:ELASTIC_API_KEY}#'"$ELASTIC_API_KEY"'#g' ./otel.yml
+    ELASTICSEARCH_ENDPOINT=<ELASTICSEARCH_ENDPOINT> && \
+    ELASTIC_API_KEY=<ELASTIC_API_KEY> && \
+    cp ./otel_samples/logs_metrics_traces.yml ./otel.yml && \
+    mkdir -p ./data/otelcol && \
+    sed -i '' "s#\${env:STORAGE_DIR}#${PWD}/data/otelcol#g" ./otel.yml && \
+    sed -i '' "s#\${env:ELASTIC_ENDPOINT}#${ELASTICSEARCH_ENDPOINT}#g" ./otel.yml && \
+    sed -i '' "s#\${env:ELASTIC_API_KEY}#${ELASTIC_API_KEY}#g" ./otel.yml
     ```
 
     *Windows*


### PR DESCRIPTION
The lack of `&&` at the end of variables setting makes them ignored in the following sed (at least in my local setup).

we can simplify a bit and remove the `rm` command as the file is overwriten with the `cp` command, also we can simplify escaping by making the sed expression interpolated rather than concatenated.

With those changes, the only difference between the macos and linux is the extra `''` argument in the inline sed invocation.