### PR TITLE
edot-sdks/feature: mark runtime metrics not-available for Python

### DIFF
--- a/docs/_edot-sdks/features.yml
+++ b/docs/_edot-sdks/features.yml
@@ -288,7 +288,7 @@ features:
       status: 
       min_version: 
     Python:
-      status: 
+      status: not-available
       min_version: 
     Android:
       status: 

--- a/docs/_edot-sdks/index.md
+++ b/docs/_edot-sdks/index.md
@@ -408,7 +408,7 @@ For languages for which Elastic does not offer its own distribution, we recommen
                 <div></div>
             </td>
             <td class="s tooltip"> <!-- Python -->
-                <div></div>
+                <div>❌</div>
             </td>
             <td class="s tooltip"> <!-- Android -->
                 <div></div>


### PR DESCRIPTION
As we don't have any in the semantic conventions yet