### PR TITLE
jekyll config: exclude vendor templates

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -84,6 +84,7 @@ edot_versions:
 # -- EDOT versions end --
 
 exclude:
+  - vendor
   - "gen_edot_col_components/"
 
 mermaid:


### PR DESCRIPTION
This fixes local build for me. Before:

```
Generating...
  Error: could not read file /home/rm/src/opentelemetry/docs/vendor/bundle/ruby/3.0.0/gems/jekyll-3.10.0/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb: Invalid date '<%= Time.now.strftime('%Y-%m-%d %H:%M:%S %z') %>': Document 'vendor/bundle/ruby/3.0.0/gems/jekyll-3.10.0/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb' does not have a valid date in the YAML front matter.

  ERROR: YOUR SITE COULD NOT BE BUILT:
     ------------------------------------
     Invalid date '<%= Time.now.strftime('%Y-%m-%d %H:%M:%S %z') %>': Document 'vendor/bundle/ruby/3.0.0/gems/jekyll-3.10.0/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb' does not have a valid date in the YAML front matter.
```

After:

```
Generating...
    done in 4.851 seconds.
 Auto-regeneration: enabled for '/home/rm/src/opentelemetry/docs'
    Server address: http://127.0.0.1:4000/opentelemetry/
  Server running... press ctrl-c to stop.
```

No idea if there are vendored stuff that is required.