### PR TITLE
EDOT Node.js docs: add '1.0+' to features table cell to follow the lead of the other langs

### DIFF
--- a/docs/_edot-sdks/features.yml
+++ b/docs/_edot-sdks/features.yml
@@ -35,7 +35,7 @@ features:
       min_version: 
     Node.js:
       status: ga
-      min_version: 
+      min_version: 1.0
     PHP:
       status: ga
       min_version: 1.0

--- a/docs/_edot-sdks/index.md
+++ b/docs/_edot-sdks/index.md
@@ -123,6 +123,8 @@ For languages for which Elastic does not offer its own distribution, we recommen
             </td>
             <td class="s tooltip"> <!-- Node.js -->
                 <div>✅</div>
+                <div class="xs">1.0+</div>
+                <div class="tooltiptext">'Service Map' is available in EDOT Node.js since version 1.0</div>
             </td>
             <td class="s tooltip"> <!-- PHP -->
                 <div>✅</div>


### PR DESCRIPTION
Refs: https://elastic.github.io/opentelemetry/edot-sdks/index.html#features
