### PR TITLE
docs: add a 'Repository' external link for EDOT Node.js

### DIFF
--- a/docs/_edot-sdks/nodejs/repository.md
+++ b/docs/_edot-sdks/nodejs/repository.md
@@ -1,0 +1,7 @@
+---
+title: Repository
+layout: default
+nav_order: 8
+parent: EDOT Node.js
+ext_link: https://github.com/elastic/elastic-otel-node
+---


### PR DESCRIPTION
Refs: https://github.com/elastic/elastic-otel-node/issues/168

Would this be reasonable? It adds a "Repository" external link to the nav:


![Screenshot 2025-04-02 at 12 42 22 PM](https://github.com/user-attachments/assets/6e649674-2e1a-4274-ae7c-5a561530e110)
