### PR TITLE
use-cases/llm: add direct link to each language llm instrumentations docs

### DIFF
--- a/docs/_edot-sdks/java/supported-technologies.md
+++ b/docs/_edot-sdks/java/supported-technologies.md
@@ -18,7 +18,9 @@ The EDOT Java agent also supports technologies listed here that are _not availab
 
 See also the [EDOT Java agent configuration](./configuration#configuration-options) for defaults that might differ from the OpenTelemetry Java Instrumentation.
 
-## OpenAI Client instrumentation (tech preview)
+## LLM instrumentations
+
+### OpenAI Client instrumentation (tech preview)
 
 Instrumentation for the [official OpenAI Java Client](https://github.com/openai/openai-java).
 

--- a/docs/_edot-sdks/nodejs/supported-technologies.md
+++ b/docs/_edot-sdks/nodejs/supported-technologies.md
@@ -71,6 +71,16 @@ The following instrumentations are included in EDOT Node.js. All are enabled by 
 | `@opentelemetry/instrumentation-undici` | `undici` version range `>=5.12.0` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-undici#readme) |
 | `@opentelemetry/instrumentation-winston` | `winston` version range `>1 <4` | [README](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-winston#readme) |
 
+### LLM instrumentations
+
+We can instrument the following LLM (Large Language Model) libraries with instrumentations implementing the [OpenTelemetry GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/):
+
+| **SDK**                     | **Instrumentation**                          | **Traces** | **Metrics** | **Logs** | **Notes** |
+|-----------------------------|----------------------------------------------|------------|-------------|----------|-----------|
+| OpenAI                      | [@elastic-opentelemetry-instrumentation-openai](https://github.com/elastic/elastic-otel-node/tree/main/packages/instrumentation-openai#readme) | ✅         | ✅          | ✅       | 1.        |
+
+1. Support for [chat](https://platform.openai.com/docs/api-reference/chat) and [embeddings](https://platform.openai.com/docs/api-reference/embeddings) API endpoints.
+
 ### Disabled instrumentations
 
 The following instrumentations are included in EDOT Node.js, but *disabled by default*:

--- a/docs/use-cases/llm/index.md
+++ b/docs/use-cases/llm/index.md
@@ -12,7 +12,7 @@ We currently support LLM observability with our EDOT Java, EDOT Node.js and EDOT
 
 # Supported Technologies
 
-| Technology | [EDOT Java](../../edot-sdks/java/supported-technologies.html#llm-instrumentations) | EDOT Node.js | [EDOT Python](../../edot-sdks/python/supported-technologies.html#llm-instrumentations) |
+| Technology | [EDOT Java](../../edot-sdks/java/supported-technologies.html#llm-instrumentations) | [EDOT Node.js](../../edot-sdks/nodejs/supported-technologies.html#llm-instrumentations) | [EDOT Python](../../edot-sdks/python/supported-technologies.html#llm-instrumentations) |
 |:-----------|:----------|:-------------|:------------|
 | OpenAI Client | ✅ | ✅ | ✅ |
 | AWS Bedrock | ❌ | ❌ | ✅ |

--- a/docs/use-cases/llm/index.md
+++ b/docs/use-cases/llm/index.md
@@ -12,7 +12,7 @@ We currently support LLM observability with our EDOT Java, EDOT Node.js and EDOT
 
 # Supported Technologies
 
-| Technology | EDOT Java | EDOT Node.js | EDOT Python |
+| Technology | [EDOT Java](../../edot-sdks/java/supported-technologies.html#llm-instrumentations) | EDOT Node.js | [EDOT Python](../../edot-sdks/python/supported-technologies.html#llm-instrumentations) |
 |:-----------|:----------|:-------------|:------------|
 | OpenAI Client | ✅ | ✅ | ✅ |
 | AWS Bedrock | ❌ | ❌ | ✅ |


### PR DESCRIPTION
Add direct link for Java and Python. In order to do that rework the java page to add an LLM instrumentations chapter.

~Will need to add the same content for Node.js and link it.~ Added nodejs chapter too.