### PR TITLE
java doc resource attrib. prov. overhead

### DIFF
--- a/docs/_edot-sdks/java/configuration.md
+++ b/docs/_edot-sdks/java/configuration.md
@@ -47,6 +47,7 @@ EDOT Java uses different defaults than the OpenTelemetry Java instrumentation fo
 |----------------------------------------------------------------------|-------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
 | `OTEL_RESOURCE_PROVIDERS_AWS_ENABLED`                                | `true`            | `false` ([docs](https://opentelemetry.io/docs/zero-code/java/agent/configuration/#enable-resource-providers-that-are-disabled-by-default))   |
 | `OTEL_RESOURCE_PROVIDERS_GCP_ENABLED`                                | `true`            | `false` ([docs](https://opentelemetry.io/docs/zero-code/java/agent/configuration/#enable-resource-providers-that-are-disabled-by-default))   |
+| `OTEL_RESOURCE_PROVIDERS_AZURE_ENABLED`                              | `true`            | `false` ([docs](https://opentelemetry.io/docs/zero-code/java/agent/configuration/#enable-resource-providers-that-are-disabled-by-default))   |
 | `OTEL_INSTRUMENTATION_RUNTIME-TELEMETRY_EMIT-EXPERIMENTAL-TELEMETRY` | `true`            | `false` ([docs](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/runtime-telemetry/README.md)) |
 | `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`                  | `delta` (*)       | `cumulative` ([docs](https://opentelemetry.io/docs/specs/otel/metrics/sdk_exporters/otlp/#additional-environment-variable-configuration))    |
 

--- a/docs/_edot-sdks/java/overhead.md
+++ b/docs/_edot-sdks/java/overhead.md
@@ -50,3 +50,15 @@ This difference is also the reason why we observe a difference in the maximum he
 in-memory when possible and not recycled by the garbage collector. This however does not mean that Elastic APM Java agent _requires_
 about 100mb more of memory compared to EDOT, but that when there is no limitation on heap memory usage the agent will
 use available memory to minimize memory allocation.
+
+## Optimizing application startup
+
+With EDOT Java, the following resource attribute providers are enabled by default:
+
+- AWS: [`OTEL_RESOURCE_PROVIDERS_AWS_ENABLED`](./configuration#configuration-options) = `true`
+- GCP: [`OTEL_RESOURCE_PROVIDERS_GCP_ENABLED`](./configuration#configuration-options) = `true`
+- Azure: [`OTEL_RESOURCE_PROVIDERS_AZURE_ENABLED`](./configuration#configuration-options) = `true`
+
+Because those resource attributes providers rely on metadata endpoints, they may require a few HTTP requests.
+When the cloud provider is known or none is being used, it might be relevant to selectively disable them by setting
+their respective configuration options to `false`.

--- a/docs/_edot-sdks/java/overhead.md
+++ b/docs/_edot-sdks/java/overhead.md
@@ -69,4 +69,4 @@ Also, each enabled instrumentation adds instrumentation overhead, this can be co
 - [disable all instrumentations and selectively enable the ones you need](https://opentelemetry.io/docs/zero-code/java/agent/disable/#enable-only-specific-instrumentation)
 
 However note that some instrumentation relies on other instrumentation to function properly.
-When selectively enabling instrumentation, be sure to enable the transitive instrumentation dependencies too.
+When selectively **enabling** instrumentation, be sure to enable the transitive instrumentation dependencies too.

--- a/docs/_edot-sdks/java/overhead.md
+++ b/docs/_edot-sdks/java/overhead.md
@@ -62,3 +62,11 @@ With EDOT Java, the following resource attribute providers are enabled by defaul
 Because those resource attributes providers rely on metadata endpoints, they may require a few HTTP requests.
 When the cloud provider is known or none is being used, it might be relevant to selectively disable them by setting
 their respective configuration options to `false`.
+
+Also, each enabled instrumentation adds instrumentation overhead, this can be controlled by applying one of the following strategies:
+
+- [disable instrumentations selectively](https://opentelemetry.io/docs/zero-code/java/agent/disable/#suppressing-specific-agent-instrumentation)
+- [disable all instrumentations and selectively enable the ones you need](https://opentelemetry.io/docs/zero-code/java/agent/disable/#enable-only-specific-instrumentation)
+
+However note that some instrumentation relies on other instrumentation to function properly.
+When selectively enabling instrumentation, be sure to enable the transitive instrumentation dependencies too.


### PR DESCRIPTION
- document how to avoid app startup overhead for resource providers.
- adds azure provider config option, even if it's not included in a release yet.