### PR TITLE
[.NET] Update EDOT defaults to reflect IncludeScopes

### DIFF
--- a/docs/_edot-sdks/dotnet/setup/edot-defaults.md
+++ b/docs/_edot-sdks/dotnet/setup/edot-defaults.md
@@ -257,9 +257,10 @@ OpenTelemetry SDK.
 | Option                   | EDOT .NET default | OpenTelemetry SDK default |
 | ------------------------ | ----------------- | ------------------------- |
 | IncludeFormattedMessage  | `true`            | `false`                   |
-| IncludeScopes            | `true` (1.0.0 to 1.0.1) *           | `false`                   |
+| IncludeScopes            | `false` (Since 1.0.2) *           | `false`                   |
 
-\* Since 1.0.2 `IncludeScopes` is no longer enabled by default. See [troubleshooting](./../troubleshooting/#missing-log-records)
+\* Since 1.0.2 `IncludeScopes` is no longer enabled by default. See [troubleshooting](./../troubleshooting/#missing-log-records).
+1.0.0 and 1.0.1 default to `true`.
 
 ### Instrumentation assembly scanning
 

--- a/docs/_edot-sdks/dotnet/setup/edot-defaults.md
+++ b/docs/_edot-sdks/dotnet/setup/edot-defaults.md
@@ -257,7 +257,9 @@ OpenTelemetry SDK.
 | Option                   | EDOT .NET default | OpenTelemetry SDK default |
 | ------------------------ | ----------------- | ------------------------- |
 | IncludeFormattedMessage  | `true`            | `false`                   |
-| IncludeScopes            | `true`            | `false`                   |
+| IncludeScopes            | `true` (1.0.0 to 1.0.1) *           | `false`                   |
+
+\* Since 1.0.2 `IncludeScopes` is no longer enabled by default. See [troubleshooting](./../troubleshooting/#missing-log-records)
 
 ### Instrumentation assembly scanning
 


### PR DESCRIPTION
Reflects a change introduced in [1.0.2](https://github.com/elastic/elastic-otel-dotnet/releases/tag/1.0.2).