### PR TITLE
Port managed OTLP endpoint content

### DIFF
--- a/docs/quickstart/serverless/hosts_vms.md
+++ b/docs/quickstart/serverless/hosts_vms.md
@@ -22,7 +22,7 @@ logs and application traces and send the data through OTLP to your Elastic Serve
 
 2. **Configure the EDOT Collector**
 
-    Retrieve the `Elastic OTLP Endpoint` and the `Elastic API Key` for your Serverless Project by [following these instructions](./#retrieving-connection-details-for-your-serverless-project).
+    Retrieve the `Elastic OTLP Endpoint` and the `Elastic API Key` for your Serverless Project by [following these instructions](./#retrieve-connection-details-for-your-project).
 
     Replace `<ELASTIC_OTLP_ENDPOINT>` and `<ELASTIC_API_KEY>` before applying the command below.
 

--- a/docs/quickstart/serverless/index.md
+++ b/docs/quickstart/serverless/index.md
@@ -23,10 +23,10 @@ The Elastic Cloud Managed OTLP Endpoint ensures that OpenTelemetry data is store
 * An Elastic Observability Serverless project.
 * An Elastic Distribution of OpenTelemetry or any system that can forward logs, metrics, or traces in OTLP format.
 
-## Retrieving connection details for your project
+## Retrieve connection details for your project
 
 {: .note }
-> The following instructions use a managed OTLP endpoint on Elastic Cloud Serverless. This feature is in **Technical Preview** and isn't yet recommended for use in production.
+> The following instructions use a managed OTLP endpoint on Elastic Cloud Serverless. This feature is in **Technical Preview** and shouldn't be used in production.
 
 Follow these steps to retrieve the managed OTLP endpoint URL for your Serverless project:
 
@@ -56,6 +56,6 @@ The managed endpoint has per-project rate limits in place. If you reach this lim
 
 ## Provide feedback
 
-Help improve the Elastic Cloud Managed OTLP Endpoint by sending us feedback in our [discussion forum](https://discuss.elastic.co/c/apm) or [community Slack](https://elasticstack.slack.com/signup#/domain-signup).
+Help improve the Elastic Cloud Managed OTLP Endpoint by sending us feedback in our [discussion forum](https://discuss.elastic.co/c/apm) or [community Slack](https://elasticstack.slack.com/signup).
 
 For EDOT collector feedback, open an issue in the [elastic-agent repository](https://github.com/elastic/elastic-agent/issues).

--- a/docs/quickstart/serverless/index.md
+++ b/docs/quickstart/serverless/index.md
@@ -20,7 +20,7 @@ The Elastic Cloud Managed OTLP Endpoint ensures that OpenTelemetry data is store
 
 ## Prerequisites
 
-* An Elastic Observability Serverless project. To learn more, refer to [create an Observability project](/solutions/observability/get-started/create-an-observability-project.md).
+* An Elastic Observability Serverless project.
 * An Elastic Distribution of OpenTelemetry or any system that can forward logs, metrics, or traces in OTLP format.
 
 ## Retrieving connection details for your project

--- a/docs/quickstart/serverless/index.md
+++ b/docs/quickstart/serverless/index.md
@@ -7,27 +7,55 @@ parent: Quickstart
 
 # Quickstart on Elastic Cloud Serverless
 
-## Retrieving Connection Details for your Serverless Project
+The Managed OTLP Endpoint simplifies OpenTelemetry data ingestion. It provides an endpoint for OpenTelemetry SDKs and Collectors to send telemetry data, with Elastic handling scaling, data processing, and storage. The Managed OTLP Endpoint is exclusively for Elastic Cloud users, initially available in Elastic Cloud Serverless only.
+
+This endpoint is designed for the following use cases:
+
+* Logs and Infrastructure Monitoring: Logs forwarded in OTLP format and host and Kubernetes metrics in OTLP format.
+* APM: Application telemetry in OTLP format.
+
+## Differences from the existing Elastic APM Endpoint
+
+The Elastic Cloud Managed OTLP Endpoint ensures that OpenTelemetry data is stored without any schema translation, preserving both OpenTelemetry semantic conventions and resource attributes. It supports ingesting OTLP logs, metrics, and traces in a unified manner, ensuring consistent treatment across all telemetry data.
+
+## Prerequisites
+
+* An Elastic Observability Serverless project. To learn more, refer to [create an Observability project](/solutions/observability/get-started/create-an-observability-project.md).
+* An Elastic Distribution of OpenTelemetry or any system that can forward logs, metrics, or traces in OTLP format.
+
+## Retrieving connection details for your project
 
 {: .note }
-> The below instructions use a managed OTLP endpoint on Elastic Cloud Serverless, this feature is in **Technical Preview** and is not yet recommended for use in production.
+> The following instructions use a managed OTLP endpoint on Elastic Cloud Serverless. This feature is in **Technical Preview** and isn't yet recommended for use in production.
 
-1. **Retrieve the managed OTLP endpoint URL** for your Serverless project
+Follow these steps to retrieve the managed OTLP endpoint URL for your Serverless project:
 
-    1. Go to the [Elastic Cloud console](https://cloud.elastic.co/){:target="_blank"}.
-    2. Next to your *project*, select `Manage`.
-    3. Next to Connection Details, select `View`.
-    4. Copy the APM endpoint.
-    5. Replace `.apm.` with `.ingest.` in the URL
-        <pre><code>
-            https://my-prj-a1b2c3<b>.apm.</b>eu-west-1.aws.elastic.cloud
-        --> https://my-prj-a1b2c3<b>.ingest.</b>eu-west-1.aws.elastic.cloud
-        </code></pre>
+   1. In Elastic Cloud, open your Observability project.
+   2. Go to **Add data**, **Application**, **OpenTelemetry**.
+   3. Select **Managed OTLP Endpoint** in the second step.
+   4. Copy the OTLP endpoint configuration value.
+   5. Select **Create API Key** to generate an API key.
 
-    This URL will be referred to as `ELASTIC_OTLP_ENDPOINT`, and API key (see below) will be required to use it.
+## Troubleshoot
 
-2. **Create an API key** 
+### Api Key prefix not found
 
-    Create an API Key following [these instructions](https://www.elastic.co/guide/en/kibana/current/api-keys.html){:target="_blank"}.
+The following error is due to an improperly formatted API key:
 
-    This API key will be referred to as `ELASTIC_API_KEY`.
+```txt
+Exporting failed. Dropping data.
+{"kind": "exporter", "data_type": }
+"Unauthenticated desc = ApiKey prefix not found"
+```
+
+Format your API key as `"Authorization": "ApiKey <api-key-value-here>"` or `"Authorization=ApiKey <api-key>"` depending on whether you're using a Collector or SDK.
+
+### Error: too many requests
+
+The managed endpoint has per-project rate limits in place. If you reach this limit, contact our [support team](https://support.elastic.co).
+
+## Provide feedback
+
+Help improve the Elastic Cloud Managed OTLP Endpoint by sending us feedback in our [discussion forum](https://discuss.elastic.co/c/apm) or [community Slack](https://elasticstack.slack.com/signup#/domain-signup).
+
+For EDOT collector feedback, open an issue in the [elastic-agent repository](https://github.com/elastic/elastic-agent/issues).

--- a/docs/quickstart/serverless/k8s.md
+++ b/docs/quickstart/serverless/k8s.md
@@ -24,7 +24,7 @@ logs collection and application monitoring.
 
 2. **Setup Connection & Credentials**
 
-    Retrieve the `Elastic OTLP Endpoint` and the `Elastic API Key` for your Serverless Project by [following these instructions](./#retrieving-connection-details-for-your-serverless-project).
+    Retrieve the `Elastic OTLP Endpoint` and the `Elastic API Key` for your Serverless Project by [following these instructions](./#retrieve-connection-details-for-your-project).
 
     Replace both, `<ELASTIC_OTLP_ENDPOINT>` and `<ELASTIC_API_KEY>` in the below command to create a namespace and a secret with your credentials.
 


### PR DESCRIPTION
Moving content following an OTel docs cleanup. See https://github.com/elastic/observability-docs/issues/4851.

Fixes https://github.com/elastic/observability-docs/issues/4851