### PR TITLE
Specify minimum required for now non-preview OpenAI Java instrumentation

### DIFF
--- a/docs/_edot-sdks/java/configuration.md
+++ b/docs/_edot-sdks/java/configuration.md
@@ -61,7 +61,7 @@ This table only contains minimal configuration, see each respective feature for 
 | `OTEL_INFERRED_SPANS_ENABLED`                          | `false` | [Inferred spans](./features#inferred-spans)                                                          |
 | `OTEL_JAVA_EXPERIMENTAL_SPAN_STACKTRACE_MIN_DURATION`  | `5ms`   | [Span stacktrace](./features#span-stacktrace)                                                        |
 | `ELASTIC_OTEL_UNIVERSAL_PROFILING_INTEGRATION_ENABLED` | `auto`  | [Elastic Universal profiling integration](./features#elastic-universal-profiling-integration)        |
-| `OTEL_INSTRUMENTATION_OPENAI_CLIENT_ENABLED`           | `true`  | [OpenAI client instrumentation](./supported-technologies#openai-client-instrumentation-tech-preview) |
+| `OTEL_INSTRUMENTATION_OPENAI_CLIENT_ENABLED`           | `true`  | [OpenAI client instrumentation](./supported-technologies#openai-client-instrumentation) |
 
 ## Configuration methods
 

--- a/docs/_edot-sdks/java/supported-technologies.md
+++ b/docs/_edot-sdks/java/supported-technologies.md
@@ -42,13 +42,12 @@ See also the [EDOT Java agent configuration](./configuration#configuration-optio
 
 ## LLM instrumentations
 
-### OpenAI Client instrumentation (tech preview)
+### OpenAI Client instrumentation
 
 Instrumentation for the [official OpenAI Java Client](https://github.com/openai/openai-java).
+The minimum supported OpenAI Java Client version is 1.1.0.
 
-Note that this instrumentation is currently in **tech preview**, because the OpenAI client itself is still in **beta**.
-
-It supports:
+This instrumentation supports:
 
 * Tracing for requests, including GenAI-specific attributes such as token usage
 * Opt-In logging of OpenAI request and response content payloads


### PR DESCRIPTION
Updates the docs https://github.com/elastic/elastic-otel-java/pull/607.
Now that the OpenAI java client is stable, we can remove the technical preview tag from the instrumentation.