### PR TITLE
docs: add host and k8s metrics collection examples

### DIFF
--- a/docs/_edot-collector/config/configure-metrics-collection.md
+++ b/docs/_edot-collector/config/configure-metrics-collection.md
@@ -7,10 +7,10 @@ nav_order: 4
 
 # Configure Metrics Collection
 
-This page contains example and references for customizing metrics collection.
+This page contains examples and references for customizing metrics collection.
 
 {: .note}
-As of Elastic Stack version {{ site.edot_versions.collector }} Elasticsearch Ingest Pipelines are not (yet) applicable to OTel-native data, see [corresponding limitation documentation](../../compatibility/limitations#centralized-parsing-and-processing-of-data).
+As of Elastic Stack version {{ site.edot_versions.collector }} Elasticsearch Ingest Pipelines are not (yet) applicable to OTel-native data; see [corresponding limitation documentation](../../compatibility/limitations#centralized-parsing-and-processing-of-data).
 Hence, we recommend using OTel collector processing pipelines for pre-processing metrics.
 {:toc}
 
@@ -36,7 +36,7 @@ Ensure your application is configured to export metrics using the OTLP protocol,
 
 ## Host metrics
 
-The [hostmetrics receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver) enables collection of host-level metrics such as CPU usage, memory utilization, and filesystem stats.
+The [hostmetrics receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver) enables the collection of host-level metrics such as CPU usage, memory utilization, and file system stats.
 
 The following configuration collects a standard set of host metrics that align with Elastic's Infrastructure dashboards in Kibana:
 
@@ -100,7 +100,7 @@ hostmetrics:
 
 Important notes:
 
- - The receiver must be granted access to the /proc filesystem, typically by running the collector with privileged access (or the corresponding capabilities) and mounting /proc and /sys appropriately. For detailed instructions, refer to the hostmetrics container usage [guide](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver#collecting-host-metrics-from-inside-a-container-linux-only) (Linux only).
+ - The receiver must be granted access to the /proc file system, typically by running the collector with privileged access (or the corresponding capabilities) and mounting /proc and /sys appropriately. For detailed instructions, refer to the hostmetrics container usage [guide](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver#collecting-host-metrics-from-inside-a-container-linux-only) (Linux only).
 
  - Enabling the process scraper can significantly increase the volume of scraped metrics, potentially impacting performance. See upstream issue [#39423](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39423) for discussion.
 
@@ -197,7 +197,7 @@ Deployment Recommendation: Run a single instance of this receiver (e.g., as a De
 
 ## Other metrics
 
-The EDOT Collector supports a wide range of metric receivers for popular software systems, including:
+The EDOT Collector supports a wide range of metrics receivers for popular software systems, including:
 
  - Redis ([redisreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/redisreceiver)): Retrieve Redis INFO data from a single Redis instance.
 

--- a/docs/_edot-collector/config/configure-metrics-collection.md
+++ b/docs/_edot-collector/config/configure-metrics-collection.md
@@ -104,7 +104,17 @@ Important notes:
 
  - Enabling the process scraper can significantly increase the volume of scraped metrics, potentially impacting performance. See upstream issue [#39423](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39423) for discussion.
 
- - To ensure compatibility with Kibana's Infrastructure dashboards, include the [elasticinframetrics processor](https://github.com/elastic/opentelemetry-collector-components/tree/main/processor/elasticinframetricsprocessor) in your pipeline.
+ - To ensure compatibility with Kibana's Infrastructure dashboards, include the [elasticinframetrics processor](https://github.com/elastic/opentelemetry-collector-components/tree/main/processor/elasticinframetricsprocessor) in your pipeline:
+
+ ```yaml
+      service:
+        pipelines:
+          metrics/infra:
+            receivers:
+              - hostmetrics
+            processors:
+              - elasticinframetrics
+ ```
 
 ## Kubernetes metrics
 

--- a/docs/_edot-collector/config/configure-metrics-collection.md
+++ b/docs/_edot-collector/config/configure-metrics-collection.md
@@ -19,7 +19,7 @@ Hence, we recommend using OTel collector processing pipelines for pre-processing
 
 Any application emitting metrics through OTLP (OpenTelemetry Protocol) can forward them to the EDOT Collector using the OTLP receiver. This is the recommended method for collecting application-level telemetry.
 
-The following OTLP receiver configuration enables both gRPC and HTTP protocols for incoming OTLP traffic:
+The following OTLP receiver configuration turns on both gRPC and HTTP protocols for incoming OTLP traffic:
 
 ```yaml
 # [OTLP Receiver](https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/otlpreceiver)
@@ -32,11 +32,11 @@ receivers:
         endpoint: 0.0.0.0:4318
 ```
 
-Ensure your application is configured to export metrics using the OTLP protocol, targeting the endpoints provided in the previous example.
+Configure your application to export metrics using the OTLP protocol, targeting the endpoints provided in the previous example.
 
 ## Host metrics
 
-The [hostmetrics receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver) enables the collection of host-level metrics such as CPU usage, memory usage, and filesystem stats.
+The [hostmetrics receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver) turns on the collection of host-level metrics such as CPU use, memory use, and filesystem stats.
 
 The following configuration collects a standard set of host metrics that aligns with Elastic's Infrastructure dashboards in Kibana:
 
@@ -98,7 +98,7 @@ hostmetrics:
         match_type: strict
 ```
 
-Note that you must grant access to the /proc filesystem to the receiver, typically by running the Collector with privileged access or the corresponding capabilities, and mounting /proc and /sys appropriately. Refer to the hostmetrics container usage [guide](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver#collecting-host-metrics-from-inside-a-container-linux-only) (Linux only).
+You must grant access to the /proc filesystem to the receiver by running the Collector with privileged access and mounting /proc and /sys appropriately. Refer to the hostmetrics container use [guide](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver#collecting-host-metrics-from-inside-a-container-linux-only) (Linux only).
 
 Enabling the process scraper might significantly increase the volume of scraped metrics, potentially impacting performance. Refer to the upstream issue [#39423](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39423) for discussion.
 
@@ -116,7 +116,7 @@ To ensure compatibility with Kibana's Infrastructure dashboards, include the [el
 
 ## Kubernetes metrics
 
-You can collect Kubernetes metrics using multiple receivers depending on the type and source of the metrics. Each receiver might require specific Kubernetes permissions. Some are best deployed as DaemonSets or singletons.
+You can collect Kubernetes metrics using multiple receivers depending on the type and source of the metrics. Each receiver might require specific Kubernetes permissions and require a deployment as DaemonSets or singletons.
 
 As with host metrics, use the [elasticinframetrics processor](https://github.com/elastic/opentelemetry-collector-components/tree/main/processor/elasticinframetricsprocessor) to ensure metrics align with the Kibana Infrastructure inventory.
 
@@ -190,7 +190,7 @@ k8s_cluster:
       enabled: true
 ```
 
-Run a single instance of this receiver, for example as a Deployment, with sufficient RBAC permissions to access the K8s API server.
+Run a single instance of this receiver, for example as a Deployment, with sufficient permissions to access the K8s API server.
 
 ## Other metrics
 
@@ -198,7 +198,7 @@ The EDOT Collector supports a wide range of metrics receivers for popular softwa
 
  - Redis ([redisreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/redisreceiver)): Retrieve Redis INFO data from a single Redis instance.
 
- - JMX-based applications ([jmxreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/jmxreceiver)): Launch a child JRE process running the JMX Metric Gatherer configured with your specified JMX connection information and target Groovy script. It then reports metrics to an implicitly created OTLP receiver.
+ - JMX-based applications ([jmxreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/jmxreceiver)): Open a child Java process running the JMX Metric Gatherer configured with your specified JMX connection information and target Groovy script. It then reports metrics to an implicitly created OTLP receiver.
 
  - Prometheus scrape targets ([prometheusreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver)): Receives metric data in [Prometheus](https://prometheus.io/) format.
 

--- a/docs/_edot-collector/config/configure-metrics-collection.md
+++ b/docs/_edot-collector/config/configure-metrics-collection.md
@@ -17,7 +17,7 @@ Hence, we recommend using OTel collector processing pipelines for pre-processing
 
 ## OTLP metrics
 
-Any application emitting metrics via OTLP (OpenTelemetry Protocol) can forward them to the EDOT Collector using the OTLP receiver. This is the recommended method for collecting application-level telemetry.
+Any application emitting metrics through OTLP (OpenTelemetry Protocol) can forward them to the EDOT Collector using the OTLP receiver. This is the recommended method for collecting application-level telemetry.
 
 The following OTLP receiver configuration enables both gRPC and HTTP protocols for incoming OTLP traffic:
 
@@ -32,13 +32,13 @@ receivers:
         endpoint: 0.0.0.0:4318
 ```
 
-Ensure your application is configured to export metrics using the OTLP protocol, targeting the endpoints provided above.
+Ensure your application is configured to export metrics using the OTLP protocol, targeting the endpoints provided in the previous example.
 
 ## Host metrics
 
-The [hostmetrics receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver) enables the collection of host-level metrics such as CPU usage, memory utilization, and file system stats.
+The [hostmetrics receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver) enables the collection of host-level metrics such as CPU usage, memory usage, and filesystem stats.
 
-The following configuration collects a standard set of host metrics that align with Elastic's Infrastructure dashboards in Kibana:
+The following configuration collects a standard set of host metrics that aligns with Elastic's Infrastructure dashboards in Kibana:
 
 ```yaml
 hostmetrics:
@@ -98,13 +98,11 @@ hostmetrics:
         match_type: strict
 ```
 
-Important notes:
+Note that you must grant access to the /proc filesystem to the receiver, typically by running the Collector with privileged access or the corresponding capabilities, and mounting /proc and /sys appropriately. Refer to the hostmetrics container usage [guide](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver#collecting-host-metrics-from-inside-a-container-linux-only) (Linux only).
 
- - The receiver must be granted access to the /proc file system, typically by running the collector with privileged access (or the corresponding capabilities) and mounting /proc and /sys appropriately. For detailed instructions, refer to the hostmetrics container usage [guide](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver#collecting-host-metrics-from-inside-a-container-linux-only) (Linux only).
+Enabling the process scraper might significantly increase the volume of scraped metrics, potentially impacting performance. Refer to the upstream issue [#39423](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39423) for discussion.
 
- - Enabling the process scraper can significantly increase the volume of scraped metrics, potentially impacting performance. See upstream issue [#39423](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39423) for discussion.
-
- - To ensure compatibility with Kibana's Infrastructure dashboards, include the [elasticinframetrics processor](https://github.com/elastic/opentelemetry-collector-components/tree/main/processor/elasticinframetricsprocessor) in your pipeline:
+To ensure compatibility with Kibana's Infrastructure dashboards, include the [elasticinframetrics processor](https://github.com/elastic/opentelemetry-collector-components/tree/main/processor/elasticinframetricsprocessor) in your pipeline:
 
  ```yaml
       service:
@@ -118,13 +116,13 @@ Important notes:
 
 ## Kubernetes metrics
 
-Kubernetes metrics can be collected using multiple receivers depending on the type and source of the metrics. Each receiver may require specific Kubernetes permissions, and some are best deployed as DaemonSets or singletons.
+You can collect Kubernetes metrics using multiple receivers depending on the type and source of the metrics. Each receiver might require specific Kubernetes permissions. Some are best deployed as DaemonSets or singletons.
 
 As with host metrics, use the [elasticinframetrics processor](https://github.com/elastic/opentelemetry-collector-components/tree/main/processor/elasticinframetricsprocessor) to ensure metrics align with the Kibana Infrastructure inventory.
 
 ### Kubelet metrics
 
-The [kubeletstats](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kubeletstatsreceiver) receiver collects resource usage stats directly from the Kubelet's /stats/summary endpoint. These stats include pod-level and node-level metrics.
+The [kubeletstats](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kubeletstatsreceiver) receiver collects resource usage stats directly from the Kubelet's /stats/summary endpoint. Stats include pod-level and node-level metrics.
 
 ```yaml
 kubeletstats:
@@ -163,8 +161,7 @@ kubeletstats:
     - container.id
 ```
 
-Deployment Recommendation: To capture stats from every node in the cluster, deploy the collector with the kubeletstats receiver as a DaemonSet.
-
+To capture stats from every node in the cluster, deploy the Collector with the kubeletstats receiver as a DaemonSet.
 
 ### Cluster metrics
 
@@ -193,7 +190,7 @@ k8s_cluster:
       enabled: true
 ```
 
-Deployment Recommendation: Run a single instance of this receiver (e.g., as a Deployment) with sufficient RBAC permissions to access the K8s API server.
+Run a single instance of this receiver, for example as a Deployment, with sufficient RBAC permissions to access the K8s API server.
 
 ## Other metrics
 


### PR DESCRIPTION
This PR provides a set of examples for infrastructure metrics collection using the OpenTelemetry Collector covering the following areas:

- host metrics
- k8s metrics
- other available receivers

The examples are based on the configuration provided during Kibana's K8s Onboarding: https://github.com/elastic/elastic-agent/blob/main/deploy/helm/edot-collector/kube-stack/values.yaml

Please, let me know if the idea behind this section is different, or we should provide more context for each section.

Fixes https://github.com/elastic/opentelemetry-dev/issues/837