### PR TITLE
docs(edot-nodejs): instr-runtime-node is now in auto-instrumentations-node

### DIFF
--- a/docs/_edot-sdks/nodejs/index.md
+++ b/docs/_edot-sdks/nodejs/index.md
@@ -11,7 +11,7 @@ The Elastic Distribution of OpenTelemetry Node.js (EDOT Node.js) is a light wrap
 
 - A single package that includes several OpenTelemetry packages as dependencies, so you only need to install and update a single package (for most use cases). This is similar to OpenTelemetry's `@opentelemetry/auto-instrumentations-node` package.
 - The [`@elastic/opentelemetry-instrumentation-openai`](https://github.com/elastic/elastic-otel-node/tree/main/packages/instrumentation-openai#readme) instrumentation for monitoring usage of the OpenAI Node.js client library.
-- Additional metrics are collected by default: `process.cpu.*` and `process.memory.*` metrics from the [host-metrics package](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/opentelemetry-host-metrics/) and `nodejs.*` and `v8js.*` metrics from the [instrumentation-runtime-node package](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-runtime-node/).
+- Additional metrics are collected by default: `process.cpu.*` and `process.memory.*` metrics from the [host-metrics package](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/opentelemetry-host-metrics/).
 
 Use EDOT Node.js with your Node.js application to automatically capture distributed tracing data, performance metrics, and logs. EDOT Node.js will automatically instrument [popular modules](./supported-technologies#instrumentations) used by your service, and send the data to your configured observability backend.
 


### PR DESCRIPTION
As of https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2786
auto-instrumentations-node v0.58.0 includes instrumentation-runtime-node
by default.
