### PR TITLE
Fix ids

### DIFF
--- a/docs/reference/edot-sdks/dotnet/configuration.md
+++ b/docs/reference/edot-sdks/dotnet/configuration.md
@@ -8,7 +8,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-dotnet
+  - id: edot-sdk
 ---
 
 # Configure the EDOT .NET SDK

--- a/docs/reference/edot-sdks/dotnet/index.md
+++ b/docs/reference/edot-sdks/dotnet/index.md
@@ -8,7 +8,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-dotnet
+  - id: edot-sdk
 ---
 
 # Elastic Distribution of OpenTelemetry .NET

--- a/docs/reference/edot-sdks/dotnet/migration.md
+++ b/docs/reference/edot-sdks/dotnet/migration.md
@@ -8,8 +8,8 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-dotnet
-  - id: apm-dotnet-agent
+  - id: edot-sdk
+  - id: apm-agent
 ---
 
 # Migrate to EDOT .NET from the Elastic APM .NET agent

--- a/docs/reference/edot-sdks/dotnet/setup/aspnet.md
+++ b/docs/reference/edot-sdks/dotnet/setup/aspnet.md
@@ -8,7 +8,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-dotnet
+  - id: edot-sdk
 ---
 
 # Set up EDOT .NET for ASP.NET applications on .NET Framework

--- a/docs/reference/edot-sdks/dotnet/setup/aspnetcore.md
+++ b/docs/reference/edot-sdks/dotnet/setup/aspnetcore.md
@@ -7,7 +7,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-dotnet
+  - id: edot-sdk
 ---
 
 # Set up EDOT .NET for ASP.NET Core applications

--- a/docs/reference/edot-sdks/dotnet/setup/console.md
+++ b/docs/reference/edot-sdks/dotnet/setup/console.md
@@ -8,7 +8,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-dotnet
+  - id: edot-sdk
 ---
 
 # Set up EDOT .NET for console applications

--- a/docs/reference/edot-sdks/dotnet/setup/edot-defaults.md
+++ b/docs/reference/edot-sdks/dotnet/setup/edot-defaults.md
@@ -8,7 +8,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-dotnet
+  - id: edot-sdk
 ---
 
 # EDOT .NET opinionated defaults

--- a/docs/reference/edot-sdks/dotnet/setup/index.md
+++ b/docs/reference/edot-sdks/dotnet/setup/index.md
@@ -8,7 +8,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-dotnet
+  - id: edot-sdk
 ---
 
 # Set up the EDOT .NET SDK

--- a/docs/reference/edot-sdks/dotnet/setup/worker-services.md
+++ b/docs/reference/edot-sdks/dotnet/setup/worker-services.md
@@ -8,7 +8,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-dotnet
+  - id: edot-sdk
 ---
 
 # Set up EDOT .NET for worker services

--- a/docs/reference/edot-sdks/dotnet/setup/zero-code.md
+++ b/docs/reference/edot-sdks/dotnet/setup/zero-code.md
@@ -8,7 +8,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-dotnet
+  - id: edot-sdk
 ---
 
 # Using profiler-based zero-code instrumentation

--- a/docs/reference/edot-sdks/java/configuration.md
+++ b/docs/reference/edot-sdks/java/configuration.md
@@ -8,7 +8,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-java
+  - id: edot-sdk
 ---
 
 # Configure the EDOT Java agent

--- a/docs/reference/edot-sdks/java/features.md
+++ b/docs/reference/edot-sdks/java/features.md
@@ -8,7 +8,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-java
+  - id: edot-sdk
 ---
 
 # Features of the EDOT Java Agent

--- a/docs/reference/edot-sdks/java/index.md
+++ b/docs/reference/edot-sdks/java/index.md
@@ -8,7 +8,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-java
+  - id: edot-sdk
 ---
 
 # Elastic Distribution of OpenTelemetry Java

--- a/docs/reference/edot-sdks/java/migration.md
+++ b/docs/reference/edot-sdks/java/migration.md
@@ -8,8 +8,8 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-java
-  - id: apm-java-agent
+  - id: edot-sdk
+  - id: apm-agent
 ---
 
 # Migrate to EDOT Java from the Elastic APM Java agent

--- a/docs/reference/edot-sdks/java/overhead.md
+++ b/docs/reference/edot-sdks/java/overhead.md
@@ -8,7 +8,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-java
+  - id: edot-sdk
 ---
 
 # Performance overhead

--- a/docs/reference/edot-sdks/java/setup/index.md
+++ b/docs/reference/edot-sdks/java/setup/index.md
@@ -8,7 +8,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-java
+  - id: edot-sdk
 ---
 
 # Set up the EDOT Java Agent

--- a/docs/reference/edot-sdks/java/setup/k8s.md
+++ b/docs/reference/edot-sdks/java/setup/k8s.md
@@ -8,7 +8,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-java
+  - id: edot-sdk
 ---
 
 # Instrumenting Java applications with EDOT SDKs on Kubernetes

--- a/docs/reference/edot-sdks/java/supported-technologies.md
+++ b/docs/reference/edot-sdks/java/supported-technologies.md
@@ -8,7 +8,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-java
+  - id: edot-sdk
 ---
 
 # Technologies supported by the EDOT Java Agent

--- a/docs/reference/edot-sdks/java/troubleshooting.md
+++ b/docs/reference/edot-sdks/java/troubleshooting.md
@@ -8,7 +8,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-java
+  - id: edot-sdk
 ---
 
 # Troubleshooting the EDOT Java Agent

--- a/docs/reference/edot-sdks/nodejs/configuration.md
+++ b/docs/reference/edot-sdks/nodejs/configuration.md
@@ -8,7 +8,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-nodejs
+  - id: edot-sdk
 ---
 
 # Configure the EDOT Node.js SDK

--- a/docs/reference/edot-sdks/nodejs/index.md
+++ b/docs/reference/edot-sdks/nodejs/index.md
@@ -8,8 +8,8 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-nodejs
-  - id: apm-node-agent
+  - id: edot-sdk
+  - id: apm-agent
 ---
 
 # Elastic Distribution of OpenTelemetry Node.js

--- a/docs/reference/edot-sdks/nodejs/migration.md
+++ b/docs/reference/edot-sdks/nodejs/migration.md
@@ -8,8 +8,8 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-nodejs
-  - id: apm-node-agent
+  - id: edot-sdk
+  - id: apm-agent
 ---
 
 # Migrate to EDOT Node.js from the Elastic APM Node.js agent

--- a/docs/reference/edot-sdks/nodejs/setup/index.md
+++ b/docs/reference/edot-sdks/nodejs/setup/index.md
@@ -8,7 +8,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-nodejs
+  - id: edot-sdk
 ---
 
 # Set up EDOT Node.js

--- a/docs/reference/edot-sdks/nodejs/setup/k8s.md
+++ b/docs/reference/edot-sdks/nodejs/setup/k8s.md
@@ -8,7 +8,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-nodejs
+  - id: edot-sdk
 ---
 
 # Instrumenting Node.js applications with EDOT SDKs on Kubernetes

--- a/docs/reference/edot-sdks/nodejs/supported-technologies.md
+++ b/docs/reference/edot-sdks/nodejs/supported-technologies.md
@@ -8,7 +8,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-nodejs
+  - id: edot-sdk
 ---
 
 # Technologies supported by the EDOT Node.js SDK

--- a/docs/reference/edot-sdks/nodejs/troubleshooting.md
+++ b/docs/reference/edot-sdks/nodejs/troubleshooting.md
@@ -8,7 +8,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-nodejs
+  - id: edot-sdk
 ---
 
 # Troubleshooting the EDOT Node.js SDK

--- a/docs/reference/edot-sdks/php/configuration.md
+++ b/docs/reference/edot-sdks/php/configuration.md
@@ -8,7 +8,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-php
+  - id: edot-sdk
 ---
 
 # Configure the EDOT PHP SDK

--- a/docs/reference/edot-sdks/php/index.md
+++ b/docs/reference/edot-sdks/php/index.md
@@ -8,7 +8,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-php
+  - id: edot-sdk
 ---
 
 # Elastic Distribution of OpenTelemetry PHP

--- a/docs/reference/edot-sdks/php/migration.md
+++ b/docs/reference/edot-sdks/php/migration.md
@@ -8,8 +8,8 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-php
-  - id: apm-php-agent
+  - id: edot-sdk
+  - id: apm-agent
 ---
 
 # Migrate to EDOT PHP from the Elastic APM PHP agent

--- a/docs/reference/edot-sdks/php/overhead.md
+++ b/docs/reference/edot-sdks/php/overhead.md
@@ -8,7 +8,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-php
+  - id: edot-sdk
 ---
 
 # Performance overhead

--- a/docs/reference/edot-sdks/php/setup/index.md
+++ b/docs/reference/edot-sdks/php/setup/index.md
@@ -8,7 +8,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-php
+  - id: edot-sdk
 ---
 
 # Set up EDOT PHP

--- a/docs/reference/edot-sdks/php/setup/limitations.md
+++ b/docs/reference/edot-sdks/php/setup/limitations.md
@@ -8,7 +8,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-php
+  - id: edot-sdk
 ---
 
 # Limitations

--- a/docs/reference/edot-sdks/php/supported-technologies.md
+++ b/docs/reference/edot-sdks/php/supported-technologies.md
@@ -8,7 +8,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-php
+  - id: edot-sdk
 ---
 
 # Technologies supported by EDOT PHP

--- a/docs/reference/edot-sdks/php/troubleshooting.md
+++ b/docs/reference/edot-sdks/php/troubleshooting.md
@@ -8,7 +8,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-php
+  - id: edot-sdk
 ---
 
 # Troubleshooting the EDOT PHP agent

--- a/docs/reference/edot-sdks/python/configuration.md
+++ b/docs/reference/edot-sdks/python/configuration.md
@@ -8,7 +8,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-python
+  - id: edot-sdk
 ---
 
 # Configure the EDOT Python agent

--- a/docs/reference/edot-sdks/python/index.md
+++ b/docs/reference/edot-sdks/python/index.md
@@ -8,7 +8,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-python
+  - id: edot-sdk
 ---
 
 # Elastic Distribution of OpenTelemetry Python

--- a/docs/reference/edot-sdks/python/migration.md
+++ b/docs/reference/edot-sdks/python/migration.md
@@ -8,8 +8,8 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-python
-  - id: apm-python-agent
+  - id: edot-sdk
+  - id: apm-agent
 ---
 
 # Migrate to EDOT Python from the Elastic APM Python agent

--- a/docs/reference/edot-sdks/python/overhead.md
+++ b/docs/reference/edot-sdks/python/overhead.md
@@ -8,7 +8,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-python
+  - id: edot-sdk
 ---
 
 # Performance overhead

--- a/docs/reference/edot-sdks/python/setup/index.md
+++ b/docs/reference/edot-sdks/python/setup/index.md
@@ -8,7 +8,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-python
+  - id: edot-sdk
 ---
 
 # Set up the EDOT Python agent

--- a/docs/reference/edot-sdks/python/setup/k8s.md
+++ b/docs/reference/edot-sdks/python/setup/k8s.md
@@ -8,7 +8,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-python
+  - id: edot-sdk
 ---
 
 # Instrumenting Python applications with EDOT SDKs on Kubernetes

--- a/docs/reference/edot-sdks/python/setup/manual-instrumentation.md
+++ b/docs/reference/edot-sdks/python/setup/manual-instrumentation.md
@@ -8,7 +8,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-python
+  - id: edot-sdk
 ---
 
 # Manual instrumentation

--- a/docs/reference/edot-sdks/python/supported-technologies.md
+++ b/docs/reference/edot-sdks/python/supported-technologies.md
@@ -8,7 +8,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-python
+  - id: edot-sdk
 ---
 
 # Technologies supported by EDOT Python

--- a/docs/reference/edot-sdks/python/troubleshooting.md
+++ b/docs/reference/edot-sdks/python/troubleshooting.md
@@ -8,7 +8,7 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-python
+  - id: edot-sdk
 ---
 
 # Troubleshooting the EDOT Python Agent


### PR DESCRIPTION
The [list of allowed products](https://docs-v3-preview.elastic.dev/elastic/docs-builder/tree/main/syntax/frontmatter#products.) in [0.35.0](https://github.com/elastic/docs-builder/pull/1256) is missing most of the EDOT values [I inserted in issue 1200](https://github.com/elastic/docs-builder/issues/1200#issuecomment-2857511801) (they were removed). This is causing the pipelines in EDOT docs to [fail](https://github.com/elastic/opentelemetry/actions/runs/15032545246/job/42247956943?pr=230). 