### PR TITLE
updatecli: bump docs/docset.yml releases

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -1,0 +1,35 @@
+---
+name: updatecli
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 5 * * 1-5"
+
+permissions:
+  contents: read
+
+env:
+  JOB_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+jobs:
+  bump:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: elastic/oblt-actions/updatecli/run@v1
+        with:
+          command: apply --config updatecli/updatecli.d/versions.yml --values updatecli/values.d/scm.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - if: ${{ failure()  }}
+        uses: elastic/oblt-actions/slack/send@v1
+        with:
+          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel-id: "#my-channel"
+          message: ":traffic_cone: updatecli failed for `${{ github.repository }}@${{ github.ref_name }}`, please look what's going on <${{ env.JOB_URL }}|here>"

--- a/updatecli/updatecli.d/versions.yml
+++ b/updatecli/updatecli.d/versions.yml
@@ -1,0 +1,143 @@
+---
+name: Bump release versions in the docs/docset.yml
+
+scms:
+  githubConfig:
+    kind: github
+    spec:
+      user: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      owner: '{{ .scm.owner }}'
+      repository: '{{ .scm.repository }}'
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      commitusingapi: true
+      branch: '{{ .scm.branch }}'
+      force: false
+
+actions:
+  elastic-agent:
+    kind: github/pullrequest
+    scmid: githubConfig
+    sourceid: latestGoVersion
+    spec:
+      automerge: false
+      labels:
+        - dependencies
+      title: '[Automation] Bump EDOT versions'
+
+sources:
+  latest-edot-dotnet-version:
+    name: Get latest release version for the elastic-otel-dotnet
+    kind: githubrelease
+    transformers:
+      - trimprefix: v
+    spec:
+      owner: elastic
+      repository: elastic-otel-dotnet
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      versionfilter:
+        kind: latest
+
+  latest-edot-java-version:
+    name: Get latest release version for the elastic-otel-java
+    kind: githubrelease
+    transformers:
+      - trimprefix: v
+    spec:
+      owner: elastic
+      repository: elastic-otel-java
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      versionfilter:
+        kind: latest
+
+  latest-edot-node-version:
+    name: Get latest release version for the elastic-otel-node
+    kind: githubrelease
+    transformers:
+      - trimprefix: v
+    spec:
+      owner: elastic
+      repository: elastic-otel-node
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      versionfilter:
+        kind: latest
+
+  latest-edot-php-version:
+    name: Get latest release version for the elastic-otel-php
+    kind: githubrelease
+    transformers:
+      - trimprefix: v
+    spec:
+      owner: elastic
+      repository: elastic-otel-php
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      versionfilter:
+        kind: latest
+
+  latest-edot-python-version:
+    name: Get latest release version for the elastic-otel-python
+    kind: githubrelease
+    transformers:
+      - trimprefix: v
+    spec:
+      owner: elastic
+      repository: elastic-otel-python
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      versionfilter:
+        kind: latest
+
+targets:
+  update-docs-docset-dotnet:
+    name: 'Update docs/docset.yml edot-dotnet {{ source "latest-edot-dotnet-version" }}'
+    scmid: githubConfig
+    sourceid: latest-edot-dotnet-version
+    kind: file
+    spec:
+      file: docs/docset.yml
+      matchpattern: '(edot-dotnet-version): (.+)'
+      replacepattern: '$1: {{ source "latest-edot-dotnet-version" }}'
+
+  update-docs-docset-java:
+    name: 'Update docs/docset.yml edot-java {{ source "latest-edot-java-version" }}'
+    scmid: githubConfig
+    sourceid: latest-edot-java-version
+    kind: file
+    spec:
+      file: docs/docset.yml
+      matchpattern: '(edot-java-version): (.+)'
+      replacepattern: '$1: {{ source "latest-edot-java-version" }}'
+
+  update-docs-docset-node:
+    name: 'Update docs/docset.yml edot-node {{ source "latest-edot-node-version" }}'
+    scmid: githubConfig
+    sourceid: latest-edot-node-version
+    kind: file
+    spec:
+      file: docs/docset.yml
+      matchpattern: '(edot-nodejs-version): (.+)'
+      replacepattern: '$1: {{ source "latest-edot-node-version" }}'
+
+  update-docs-docset-php:
+    name: 'Update docs/docset.yml edot-php {{ source "latest-edot-php-version" }}'
+    scmid: githubConfig
+    sourceid: latest-edot-php-version
+    kind: file
+    spec:
+      file: docs/docset.yml
+      matchpattern: '(edot-php-version): (.+)'
+      replacepattern: '$1: {{ source "latest-edot-php-version" }}'
+
+  update-docs-docset-python:
+    name: 'Update docs/docset.yml edot-python {{ source "latest-edot-python-version" }}'
+    scmid: githubConfig
+    sourceid: latest-edot-python-version
+    kind: file
+    spec:
+      file: docs/docset.yml
+      matchpattern: '(edot-python-version): (.+)'
+      replacepattern: '$1: {{ source "latest-edot-python-version" }}'

--- a/updatecli/values.d/scm.yml
+++ b/updatecli/values.d/scm.yml
@@ -1,0 +1,5 @@
+scm:
+  enabled: true
+  owner: elastic
+  repository: opentelemetry
+  branch: main


### PR DESCRIPTION
### What

Use [updatecli](https://www.updatecli.io/) to help update the yaml file containing the EDOT releases.

### Why

No more manual actions and automate the docs generation.

### Tasks

- [ ] Agree on the slack channel to be used if any failures
- [ ] Test if the GH actions ecosystem works as expected (the existing GH Token might need some tweaks...)
- [ ] Support for some other EDOT agents (android, ios)
- [ ] Support for the OTEL collector or stack


### Question

- Use latest releases regardless?


### Test

I created a new branch based on this PR, so I could use a different target branch instead of `main` and the `elastic` org but my forked repository,  https://github.com/v1v/opentelemetry/pull/1 was created successfully.

```bash
$ GITHUB_TOKEN=$(gh auth token) \
  GITHUB_ACTOR=v1v \
  updatecli apply --config updatecli/updatecli.d/versions.yml --values updatecli/values.d/scm.yml
```

### Further details

We use `updatecli` in different places to automate some ad-hoc processes that requires some GH PR creation.
