### PR TITLE
updatecli: support ios, android and collector

### DIFF
--- a/updatecli/updatecli.d/versions.yml
+++ b/updatecli/updatecli.d/versions.yml
@@ -25,6 +25,33 @@ actions:
       title: '[Automation] Bump EDOT versions'
 
 sources:
+  latest-edot-android-version:
+    name: Get latest release version for the apm-agent-android
+    kind: githubrelease
+    transformers:
+      - trimprefix: v
+    spec:
+      owner: elastic
+      repository: apm-agent-android
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      versionfilter:
+        kind: latest
+
+  latest-edot-collector-version:
+    name: Get latest major release version for the elastic-agent
+    kind: githubrelease
+    transformers:
+      - trimprefix: v
+    spec:
+      owner: elastic
+      repository: elastic-agent
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      versionFilter:
+        kind: regex
+        pattern: "v9.(\\d*).(\\d*)$"
+
   latest-edot-dotnet-version:
     name: Get latest release version for the elastic-otel-dotnet
     kind: githubrelease
@@ -33,6 +60,19 @@ sources:
     spec:
       owner: elastic
       repository: elastic-otel-dotnet
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      versionfilter:
+        kind: latest
+
+  latest-edot-ios-version:
+    name: Get latest release version for the apm-agent-ios
+    kind: githubrelease
+    transformers:
+      - trimprefix: v
+    spec:
+      owner: elastic
+      repository: apm-agent-ios
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       versionfilter:
@@ -91,6 +131,26 @@ sources:
         kind: latest
 
 targets:
+  update-docs-docset-android:
+    name: 'Update docs/docset.yml edot-android {{ source "latest-edot-android-version" }}'
+    scmid: githubConfig
+    sourceid: latest-edot-android-version
+    kind: file
+    spec:
+      file: docs/docset.yml
+      matchpattern: '(edot-android-version): (.+)'
+      replacepattern: '$1: {{ source "latest-edot-android-version" }}'
+
+  update-docs-docset-collector:
+    name: 'Update docs/docset.yml edot-collector {{ source "latest-edot-collector-version" }}'
+    scmid: githubConfig
+    sourceid: latest-edot-collector-version
+    kind: file
+    spec:
+      file: docs/docset.yml
+      matchpattern: '(edot-collector-version): (.+)'
+      replacepattern: '$1: {{ source "latest-edot-collector-version" }}'
+
   update-docs-docset-dotnet:
     name: 'Update docs/docset.yml edot-dotnet {{ source "latest-edot-dotnet-version" }}'
     scmid: githubConfig
@@ -100,6 +160,16 @@ targets:
       file: docs/docset.yml
       matchpattern: '(edot-dotnet-version): (.+)'
       replacepattern: '$1: {{ source "latest-edot-dotnet-version" }}'
+
+  update-docs-docset-ios:
+    name: 'Update docs/docset.yml edot-android {{ source "latest-edot-ios-version" }}'
+    scmid: githubConfig
+    sourceid: latest-edot-ios-version
+    kind: file
+    spec:
+      file: docs/docset.yml
+      matchpattern: '(edot-ios-version): (.+)'
+      replacepattern: '$1: {{ source "latest-edot-ios-version" }}'
 
   update-docs-docset-java:
     name: 'Update docs/docset.yml edot-java {{ source "latest-edot-java-version" }}'


### PR DESCRIPTION
### What

Add ios, android and collector update versions.

### Test

```diff
diff --git a/updatecli/values.d/scm.yml b/updatecli/values.d/scm.yml
index 28d40a3..b49f955 100644
--- a/updatecli/values.d/scm.yml
+++ b/updatecli/values.d/scm.yml
@@ -1,5 +1,5 @@
 scm:
   enabled: true
-  owner: elastic
+  owner: v1v
   repository: opentelemetry
-  branch: main
\ No newline at end of file
+  branch: test/add-other-project
\ No newline at end of file
```

Then I ran:


```bash
  GITHUB_TOKEN=$(gh auth token) \
  GITHUB_ACTOR=v1v \
  updatecli apply \
    --config updatecli/updatecli.d/versions.yml \
    --values updatecli/values.d/scm.yml`
```

it produced

```


⚠ Bump release versions in the docs/docset.yml:
	Source:
		✔ [latest-edot-android-version] Get latest release version for the apm-agent-android
		✔ [latest-edot-collector-version] Get latest major release version for the elastic-agent
		✔ [latest-edot-dotnet-version] Get latest release version for the elastic-otel-dotnet
		✔ [latest-edot-ios-version] Get latest release version for the apm-agent-ios
		✔ [latest-edot-java-version] Get latest release version for the elastic-otel-java
		✔ [latest-edot-node-version] Get latest release version for the elastic-otel-node
		✔ [latest-edot-php-version] Get latest release version for the elastic-otel-php
		✔ [latest-edot-python-version] Get latest release version for the elastic-otel-python
	Target:
		⚠ [update-docs-docset-android] Update docs/docset.yml edot-android 1.0.0
		⚠ [update-docs-docset-collector] Update docs/docset.yml edot-collector 9.0.1
		⚠ [update-docs-docset-dotnet] Update docs/docset.yml edot-dotnet 1.0.2
		⚠ [update-docs-docset-ios] Update docs/docset.yml edot-android 1.2.1
		⚠ [update-docs-docset-java] Update docs/docset.yml edot-java 1.4.1
		⚠ [update-docs-docset-node] Update docs/docset.yml edot-node 1.0.0
		⚠ [update-docs-docset-php] Update docs/docset.yml edot-php 1.0.0
		⚠ [update-docs-docset-python] Update docs/docset.yml edot-python 1.2.0


Run Summary
===========
Pipeline(s) run:
  * Changed:	1
  * Failed:	0
  * Skipped:	0
  * Succeeded:	0
  * Total:	1

One action to follow up:
  * https://github.com/v1v/opentelemetry/pull/2

```

and created https://github.com/v1v/opentelemetry/pull/2