### PR TITLE
gh-actions: use github app

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -29,6 +29,8 @@ jobs:
               "contents": "write",
               "pull_requests": "write"
             }
+          repositories: >-
+            ["opentelemetry"]
 
       - uses: elastic/oblt-actions/updatecli/run@v1
         with:

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -14,18 +14,27 @@ env:
 
 jobs:
   bump:
-    permissions:
-      contents: write
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "contents": "write",
+              "pull_requests": "write"
+            }
 
       - uses: elastic/oblt-actions/updatecli/run@v1
         with:
           command: apply --config updatecli/updatecli.d/versions.yml --values updatecli/values.d/scm.yml
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
 
       - if: ${{ failure()  }}
         uses: elastic/oblt-actions/slack/send@v1


### PR DESCRIPTION
### What

Use the GH app with the specific permissions to this repository

### Why

this will help with running GH actions as the author is tnot GH actions bot, see https://github.com/orgs/community/discussions/55906

### Tasks

- [ ] Enrol the GH app on this repository
- [ ] Create GH secrets