### PR TITLE
Add Gateway config

### DIFF
--- a/docs/reference/edot-collector/config/default-config-standalone.md
+++ b/docs/reference/edot-collector/config/default-config-standalone.md
@@ -18,7 +18,7 @@ The default configuration of the {{edot}} (EDOT) Collector includes pipelines fo
 The EDOT Collector can run in [Agent](https://opentelemetry.io/docs/collector/deployment/agent/) or [Gateway](https://opentelemetry.io/docs/collector/deployment/gateway/) mode:
 
 - Agent mode: The EDOT Collector ingests data from infrastructure and SDKs and forwards it to Elastic or to another collector running in Gateway mode.
-- Gateway mode: The EDOT Collector ingests data from other collectors running in Agent mode and forward it to Elastic.
+- Gateway mode: The EDOT Collector ingests data from other collectors running in Agent mode and forwards it to Elastic.
 
 ## Agent mode
 


### PR DESCRIPTION
This adds the Gateway config to the existing standalone docs.

Fixes https://github.com/elastic/observability-docs/issues/4874

Contributes to https://github.com/elastic/ingest-dev/issues/5560