### PR TITLE
Update k8s.md

### DIFF
--- a/docs/reference/quickstart/ech/k8s.md
+++ b/docs/reference/quickstart/ech/k8s.md
@@ -65,10 +65,10 @@ On Windows PowerShell, replace backslashes (`\`) with backticks (`` ` ``) for li
 
 Install the OpenTelemetry Operator using the `kube-stack` Helm chart with the configured `values.yaml` file.
 
-```bash
+```bash subs=true
 helm install opentelemetry-kube-stack open-telemetry/opentelemetry-kube-stack \
 --namespace opentelemetry-operator-system \
---values 'https://raw.githubusercontent.com/elastic/elastic-agent/main/deploy/helm/edot-collector/kube-stack/values.yaml' \
+--values 'https://raw.githubusercontent.com/elastic/elastic-agent/{{edot-collector-version}}/deploy/helm/edot-collector/kube-stack/values.yaml' \
 --version '0.3.9'
 ```
 ::::


### PR DESCRIPTION
There is a typo in the quickstart docs: https://www.elastic.co/docs/reference/opentelemetry/quickstart/ech/k8s

Specifically in step 3, as the url for the `values.yaml` file points to main branch which uses version 9.1.0, still not released


```
helm install opentelemetry-kube-stack open-telemetry/opentelemetry-kube-stack \
--namespace opentelemetry-operator-system \
--values 'https://raw.githubusercontent.com/elastic/elastic-agent/main/deploy/helm/edot-collector/kube-stack/values.yaml' \
--version '0.3.9'
```

We need to define the current version:


```
helm install opentelemetry-kube-stack open-telemetry/opentelemetry-kube-stack \
--namespace opentelemetry-operator-system \
--values 'https://raw.githubusercontent.com/elastic/elastic-agent/refs/tags/{{edot-collector-version}}/deploy/helm/edot-collector/kube-stack/values.yaml' \
--version '0.3.9'
```

