### PR TITLE
Add troubleshooting guide for OOMKilled EDOT Collector pods using pprof

### DIFF
--- a/docs/reference/edot-collector/troubleshooting.md
+++ b/docs/reference/edot-collector/troubleshooting.md
@@ -9,22 +9,9 @@ products:
   - id: cloud-serverless
   - id: observability
   - id: edot-collector
+layout: redirection
+permalink: /edot-collector/troubleshooting.html
+redirect: https://www.elastic.co/docs/reference/opentelemetry/edot-collector/troubleshooting/index.html
 ---
 
-# Troubleshoot the EDOT Collector
-
-Perform these checks when troubleshooting Collector issues:
-
-* Check Logs: Review the Collector’s logs for error messages.
-* Validate Configuration: Use the `--dry-run` option to test configurations.
-* Enable Debug Logging: Run the Collector with `--log-level=debug` for detailed logs.
-* Check Service Status: Ensure the Collector is running with `systemctl status <collector-service>` (Linux) or `tasklist` (Windows).
-* Test Connectivity: Use `telnet <endpoint> <port>` or `curl` to verify backend availability.
-* Check Open Ports: Run netstat `-tulnp or lsof -i` to confirm the Collector is listening.
-* Monitor Resource Usage: Use top/htop (Linux) or Task Manager (Windows) to check CPU & memory.
-* Validate Exporters: Ensure exporters are properly configured and reachable.
-* Verify Pipelines: Use `otelctl` diagnose (if available) to check pipeline health.
-* Check Permissions: Ensure the Collector has the right file and network permissions.
-* Review Recent Changes: Roll back recent config updates if the issue started after changes.
-
-For in-depth details on troubleshooting refer to the [OpenTelemetry Collector troubleshooting documentation](https://opentelemetry.io/docs/collector/troubleshooting/)
+# Troubleshooting

--- a/docs/reference/edot-collector/troubleshooting.md
+++ b/docs/reference/edot-collector/troubleshooting.md
@@ -1,5 +1,5 @@
 ---
-navigation_title: Troubleshooting
+navigation_title: Troubleshoot the EDOT Collector
 description: Troubleshooting tips and resources for the EDOT Collector.
 applies_to:
   stack:
@@ -11,9 +11,9 @@ products:
   - id: edot-collector
 ---
 
-# Troubleshooting
+# Troubleshoot the EDOT Collector
 
-This section provides guidance for resolving common issues with the EDOT Collector:
+This section provides guidance for solving common issues with the EDOT Collector:
 
 - For general troubleshooting steps, refer to [Troubleshoot the EDOT Collector](troubleshooting/index.md).
 - If your EDOT Collector is running out of memory and pods are terminating with an `OOMKilled` status, refer to [EDOT Collector is out of memory](troubleshooting/collector-oomkilled.md).

--- a/docs/reference/edot-collector/troubleshooting.md
+++ b/docs/reference/edot-collector/troubleshooting.md
@@ -9,9 +9,11 @@ products:
   - id: cloud-serverless
   - id: observability
   - id: edot-collector
-layout: redirection
-permalink: /edot-collector/troubleshooting.html
-redirect: https://www.elastic.co/docs/reference/opentelemetry/edot-collector/troubleshooting/index.html
 ---
 
 # Troubleshooting
+
+This section provides guidance for resolving common issues with the EDOT Collector:
+
+- For general troubleshooting steps, refer to [Troubleshoot the EDOT Collector](troubleshooting/index.md).
+- If your EDOT Collector is running out of memory and pods are terminating with an `OOMKilled` status, refer to [EDOT Collector is out of memory](troubleshooting/collector-oomkilled.md).

--- a/docs/reference/edot-collector/troubleshooting/collector-oomkilled.md
+++ b/docs/reference/edot-collector/troubleshooting/collector-oomkilled.md
@@ -13,22 +13,23 @@ products:
 
 # EDOT Collector is out of memory
 
-If your EDOT Collector is being terminated with an `OOMKilled` status, this usually indicates a memory leak or sustained memory pressure. You can use the Performance Profiler (`pprof`) tool to collect and analyze memory profiles, helping you identify the root cause.
+If your EDOT Collector pods terminate with an `OOMKilled` status, this usually indicates sustained memory pressure or potentially a memory leak due to an introduced regression or bug. You can use the Performance Profiler (`pprof`) extension to collect and analyze memory profiles, helping you identify the root cause of the issue.
 
 ## Symptoms
 
+These symptoms typically indicate that the EDOT Collector is experiencing a memory-related failure:
+
 - EDOT Collector pod restarts with an `OOMKilled` status in Kubernetes.
 - Memory usage steadily increases before the crash.
-- The collector's logs don't show clear errors before termination.
+- The Collector's logs don't show clear errors before termination.
 
 ## Resolution
 
-Enable runtime profiling using the `pprof` extension and then gather memory heap profiles from the affected pod:
+Turn on runtime profiling using the `pprof` extension and then gather memory heap profiles from the affected pod:
 
-:::::{stepper}
+::::::{stepper}
 
-::::{step}
-**Enable `pprof` in the Collector**
+:::::{step} Enable `pprof` in the Collector
 
 Edit the EDOT Collector Daemonset configuration and include the `pprof` extension:
 
@@ -54,10 +55,9 @@ service:
 ```
 
 Restart the Collector after applying these changes. When the Daemonset is deployed again, spot the pod that is getting restarted.
-::::
+:::::
 
-::::{step}
-**Access the affected pod and collect a heap dump**
+:::::{step} Access the affected pod and collect a heap dump
 
 When a pod starts exhibiting high memory usage or restarts due to OOM, run the following to enter a debug shell:
 
@@ -72,10 +72,9 @@ apt update
 apt install -y curl
 curl http://localhost:1777/debug/pprof/heap > heap.out
 ```
-::::
+:::::
 
-::::{step}
-**Copy the heap file from the pod**
+:::::{step} Copy the heap file from the pod
 
 From your local machine, copy the heap file using:
 
@@ -85,23 +84,25 @@ kubectl cp <collector-pod-name>:heap.out ./heap.out -c <debug-container-name>
 ::::{note}
 Replace `<debug-container-name>` with the name assigned to the debug container. Without the `-c` flag, Kubernetes will show the list of available containers.
 ::::
-::::
+:::::
 
-::::{step}
-**Convert the heap profile for analysis**
+:::::{step} Convert the heap profile for analysis
 
 You can now generate a visual representation, for example PNG:
 
 ```bash
 go tool pprof -png heap.out > heap.png
 ```
-::::
+:::::
+::::::
 
 ## Best practices
 
+To improve the effectiveness of memory diagnostics and reduce investigation time, consider the following:
+
 - Collect multiple heap profiles over time (for example, every few minutes) to observe memory trends before the crash.
 
-- Consider automating heap profile collection at intervals to observe trends over time.
+- Automate heap profile collection at intervals to observe trends over time.
 
 ## Resources
 

--- a/docs/reference/edot-collector/troubleshooting/collector-oomkilled.md
+++ b/docs/reference/edot-collector/troubleshooting/collector-oomkilled.md
@@ -1,5 +1,5 @@
 ---
-navigation_title: EDOT Collector is out of memory
+navigation_title: Collector out of memory
 description: Diagnose and resolve out-of-memory issues in the EDOT Collector using Go’s Performance Profiler.
 applies_to:
   stack:
@@ -11,7 +11,7 @@ products:
   - id: edot-collector
 ---
 
-# EDOT Collector is out of memory
+# Troubleshoot an out-of-memory EDOT Collector
 
 If your EDOT Collector pods terminate with an `OOMKilled` status, this usually indicates sustained memory pressure or potentially a memory leak due to an introduced regression or a bug. You can use the Performance Profiler (`pprof`) extension to collect and analyze memory profiles, helping you identify the root cause of the issue.
 

--- a/docs/reference/edot-collector/troubleshooting/collector-oomkilled.md
+++ b/docs/reference/edot-collector/troubleshooting/collector-oomkilled.md
@@ -13,7 +13,7 @@ products:
 
 # EDOT Collector is out of memory
 
-If your EDOT Collector pods terminate with an `OOMKilled` status, this usually indicates sustained memory pressure or potentially a memory leak due to an introduced regression or bug. You can use the Performance Profiler (`pprof`) extension to collect and analyze memory profiles, helping you identify the root cause of the issue.
+If your EDOT Collector pods terminate with an `OOMKilled` status, this usually indicates sustained memory pressure or potentially a memory leak due to an introduced regression or a bug. You can use the Performance Profiler (`pprof`) extension to collect and analyze memory profiles, helping you identify the root cause of the issue.
 
 ## Symptoms
 

--- a/docs/reference/edot-collector/troubleshooting/index.md
+++ b/docs/reference/edot-collector/troubleshooting/index.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Troubleshooting
-description: Troubleshooting tips and resources for the EDOT Collector.
+description: Troubleshooting common issues with the EDOT Collector.
 applies_to:
   stack:
   serverless:
@@ -27,4 +27,4 @@ Perform these checks when troubleshooting Collector issues:
 * Check Permissions: Ensure the Collector has the right file and network permissions.
 * Review Recent Changes: Roll back recent config updates if the issue started after changes.
 
-For in-depth details on troubleshooting refer to the [OpenTelemetry Collector troubleshooting documentation](https://opentelemetry.io/docs/collector/troubleshooting/)
+For in-depth details on troubleshooting refer to the [OpenTelemetry Collector troubleshooting documentation](https://opentelemetry.io/docs/collector/troubleshooting/).

--- a/docs/reference/edot-collector/troubleshooting/index.md
+++ b/docs/reference/edot-collector/troubleshooting/index.md
@@ -1,0 +1,30 @@
+---
+navigation_title: Troubleshooting
+description: Troubleshooting tips and resources for the EDOT Collector.
+applies_to:
+  stack:
+  serverless:
+    observability:
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: edot-collector
+---
+
+# Troubleshoot the EDOT Collector
+
+Perform these checks when troubleshooting Collector issues:
+
+* Check Logs: Review the Collector’s logs for error messages.
+* Validate Configuration: Use the `--dry-run` option to test configurations.
+* Enable Debug Logging: Run the Collector with `--log-level=debug` for detailed logs.
+* Check Service Status: Ensure the Collector is running with `systemctl status <collector-service>` (Linux) or `tasklist` (Windows).
+* Test Connectivity: Use `telnet <endpoint> <port>` or `curl` to verify backend availability.
+* Check Open Ports: Run netstat `-tulnp or lsof -i` to confirm the Collector is listening.
+* Monitor Resource Usage: Use top/htop (Linux) or Task Manager (Windows) to check CPU & memory.
+* Validate Exporters: Ensure exporters are properly configured and reachable.
+* Verify Pipelines: Use `otelctl` diagnose (if available) to check pipeline health.
+* Check Permissions: Ensure the Collector has the right file and network permissions.
+* Review Recent Changes: Roll back recent config updates if the issue started after changes.
+
+For in-depth details on troubleshooting refer to the [OpenTelemetry Collector troubleshooting documentation](https://opentelemetry.io/docs/collector/troubleshooting/)

--- a/docs/reference/toc.yml
+++ b/docs/reference/toc.yml
@@ -54,6 +54,9 @@ toc:
           - file: edot-collector/components.md
           - file: edot-collector/custom-collector.md
       - file: edot-collector/troubleshooting.md
+      - file: edot-collector/troubleshooting/index.md
+        children:
+        - file: edot-collector/troubleshooting/collector-oomkilled.md
   - file: edot-sdks/index.md
     children:
       - file: edot-sdks/dotnet/index.md

--- a/docs/reference/toc.yml
+++ b/docs/reference/toc.yml
@@ -53,7 +53,6 @@ toc:
         children:
           - file: edot-collector/components.md
           - file: edot-collector/custom-collector.md
-      - file: edot-collector/troubleshooting.md
       - file: edot-collector/troubleshooting/index.md
         children:
         - file: edot-collector/troubleshooting/collector-oomkilled.md


### PR DESCRIPTION
This PR adds a new troubleshooting section for the EDOT Collector, explaining how to use the `pprof` extension to diagnose `OOMKilled` (out-of-memory) errors.

Related to [this issue](https://github.com/elastic/opentelemetry-dev/issues/933).