### PR TITLE
Correct EDOT Node.js docs for ELASTIC_OTEL_METRICS_DISABLED and ELASTIC_OTEL_HOST_METRICS_DISABLED

### DIFF
--- a/docs/reference/edot-sdks/nodejs/configuration.md
+++ b/docs/reference/edot-sdks/nodejs/configuration.md
@@ -66,6 +66,7 @@ The 🔹 symbol denotes settings with a default value or behavior that differs b
 | `OTEL_NODE_ENABLED_INSTRUMENTATIONS` 🔹 | [(EDOT Ref)](#otel_node_disabledenabled_instrumentations-details) Comma-separated list of instrumentations to turn on. |
 | `OTEL_NODE_DISABLED_INSTRUMENTATIONS` 🔹 | [(EDOT Ref)](#otel_node_disabledenabled_instrumentations-details) Comma-separated list of instrumentations to turn off. |
 | | |
+| `ELASTIC_OTEL_HOST_METRICS_DISABLED` 🔹 | [(EDOT Ref)](#elastic_otel_host_metrics_disabled-details) Disable collection of metrics done by `@opentelemetry/host-metrics` package. |
 | `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` 🔹 | [(EDOT Ref)](#otel_exporter_otlp_metrics_temporality_preference-details) The metrics exporter's default aggregation `temporality`. The default value is `delta`. The upstream OTel default is `cumulative`. |
 | | |
 | `OTEL_SEMCONV_STABILITY_OPT_IN` 🔹 | [(EDOT Ref)](#otel_semconv_stability_opt_in-details) Control which HTTP semantic conventions are used by `@opentelemetry/instrumentation-http`. The default value is `http`. The upstream OTel default is an empty value. |
@@ -109,7 +110,8 @@ The following settings are deprecated:
 
 | Name | Notes |
 | :--- | :---- |
-| `ELASTIC_OTEL_HOST_METRICS_DISABLED` 🔹 | [(EDOT Ref)](#elastic_otel_host_metrics_disabled-details) Turns off collection of metrics done by `@opentelemetry/host-metrics` package. |
+| `ELASTIC_OTEL_METRICS_DISABLED` 🔹 | [(EDOT Ref)](#deprecated-elastic_otel_metrics_disabled-details) Disable metrics export and some metrics collection by the SDK. |
+
 
 ## EDOT configuration details
 
@@ -157,20 +159,18 @@ EDOT Node.js handles these settings the same as the upstream [`@opentelemetry/au
 ```bash
 export OTEL_NODE_ENABLED_INSTRUMENTATIONS=http,fastify,pino,@elastic/opentelemetry-instrumentation-openai
 ```
+
 ### (Deprecated) `ELASTIC_OTEL_METRICS_DISABLED` details [deprecated-elastic_otel_metrics_disabled-details]
 
-EDOT Node.js enables the collection and export of metrics by default. If you wish to disable metrics you can by setting the environment variable `ELASTIC_OTEL_METRICS_DISABLED` to the string `true`.
+Setting `ELASTIC_OTEL_METRICS_DISABLED` to `true` will disable metrics export by the SDK and some metrics collection.  This configuration setting is deprecated (as of v1.1.0), in favor of using the following settings for finer control:
 
-Setting `ELASTIC_OTEL_METRICS_DISABLED=true` is similar to setting `OTEL_METRICS_EXPORTER=none`, in that it ensures no metrics are exported by the SDK. However, this setting will also disable the collection of metrics by the `@opentelemetry/host-metrics` and `@opentelemetry/instrumentation-runtime-node` packages, which can be a minor performace improvement.
-
-You can achieve better control of the metrics by setting the appropiate values through the `OTEL_NODE_{DISABLED,ENABLED}_INSTRUMENTATIONS` and `ELASTIC_OTEL_HOST_METRICS_DISABLED` environment variables.
-
-- To turn off collection for the `@opentelemetry/host-metrics` package, set `ELASTIC_OTEL_HOST_METRICS_DISABLED` to `false`.
-- To turn off collection for the `@opentelemetry/instrumentation-runtime-node` package, set `OTEL_NODE_{DISABLED,ENABLED}_INSTRUMENTATIONS` to exclude that instrumentation. [(EDOT Ref)](#otel_node_disabledenabled_instrumentations-details)
+- To turn off the export of *any and all* metrics, set `OTEL_METRICS_EXPORTER=none`.
+- To turn off collection by the `@opentelemetry/instrumentation-runtime-node` package, set `OTEL_NODE_{DISABLED,ENABLED}_INSTRUMENTATIONS` to exclude that instrumentation. For example, `OTEL_NODE_DISABLED_INSTRUMENTATIONS=runtime-node`. [(EDOT Ref)](#otel_node_disabledenabled_instrumentations-details)
+- To turn off metrics collection by the `@opentelemetry/host-metrics` package, set `ELASTIC_OTEL_HOST_METRICS_DISABLED` to `false`.
 
 ### `ELASTIC_OTEL_HOST_METRICS_DISABLED` details [elastic_otel_host_metrics_disabled-details]
 
-EDOT Node.js collects and export host metrics by default. To turn off metrics collected through the `@opentelemetry/host-metrics` package, set the `ELASTIC_HOST_OTEL_METRICS_DISABLED` environment variable to `true`.
+EDOT Node.js collects and exports [host metrics](./metrics#process-and-runtime-metrics) by default, using the `@opentelemetry/host-metrics` package. To disable this, set the `ELASTIC_HOST_OTEL_METRICS_DISABLED` environment variable to `true`.
 
 ### `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` details [otel_exporter_otlp_metrics_temporality_preference-details]
 

--- a/docs/reference/edot-sdks/nodejs/metrics.md
+++ b/docs/reference/edot-sdks/nodejs/metrics.md
@@ -13,14 +13,12 @@ products:
 
 # Metrics
 
-In the Elastic Distribution for Node.js (EDOT Node.js) metrics are turned on by default and sent to the endpoint
-you've configured. To adjust how often metric data is exported and the maximum time to export data, you can use
-the environment variables already defined in [the spec](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#periodic-exporting-metricreader).
+In the Elastic Distribution of OpenTelemetry for Node.js (EDOT Node.js) the collection of metrics is turned on by default. See the [settings with `METRIC` in the name](./configuration) for all options for configuring metric collection.
 
 ## Process and runtime metrics
 
 EDOT Node.js gathers metrics from the Node.js process your application is
-running. To gather metrics, EDOT Node.js uses the following packages:
+running using the following packages:
 
 - `@opentelemetry/host-metrics` to gather `process.cpu.*` and `process.memory.*` metrics ([ref](https://github.com/open-telemetry/semantic-conventions/blob/80988c54712ee336cb3a6240b8845e9dfa8c9f49/docs/system/process-metrics.md?plain=1#L22)).
 - `@opentelemetry/instrumentation-runtime-node` to gather `nodejs.eventloop.*` ([ref](https://github.com/open-telemetry/semantic-conventions/blob/80988c54712ee336cb3a6240b8845e9dfa8c9f49/model/nodejs/metrics.yaml)) and `v8js.*` ([ref](https://github.com/open-telemetry/semantic-conventions/blob/80988c54712ee336cb3a6240b8845e9dfa8c9f49/model/v8js/metrics.yaml)) metrics.


### PR DESCRIPTION
Mention of the former was incorrectly dropped, and the latter was incorrectly documented as deprecated in https://github.com/elastic/opentelemetry/pull/230/commits/a49845f3e6d9c50739568b6a512ce61cf365ceea
