### PR TITLE
updatecli: use regex semver for the otel-node releases

### DIFF
--- a/updatecli/updatecli.d/versions.yml
+++ b/updatecli/updatecli.d/versions.yml
@@ -103,7 +103,7 @@ sources:
       username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       versionFilter:
         kind: regex
-        pattern: "v(\\d*).(\\d*).(\\d*)$"
+        pattern: "^v(\\d*).(\\d*).(\\d*)$"
 
   latest-edot-php-version:
     name: Get latest release version for the elastic-otel-php

--- a/updatecli/updatecli.d/versions.yml
+++ b/updatecli/updatecli.d/versions.yml
@@ -101,8 +101,9 @@ sources:
       repository: elastic-otel-node
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "GITHUB_ACTOR" }}'
-      versionfilter:
-        kind: latest
+      versionFilter:
+        kind: regex
+        pattern: "v(\\d*).(\\d*).(\\d*)$"
 
   latest-edot-php-version:
     name: Get latest release version for the elastic-otel-php


### PR DESCRIPTION
Fixes different release names in the otel-node project, see https://github.com/elastic/opentelemetry/pull/280
Version is now:

<img width="1202" alt="image" src="https://github.com/user-attachments/assets/fc8c52aa-3d14-494c-872e-cb38e3074cd7" />


Test PR: https://github.com/v1v/opentelemetry/pull/3