### PR TITLE
Replace mode with form

### DIFF
--- a/docs/reference/architecture/k8s.md
+++ b/docs/reference/architecture/k8s.md
@@ -12,13 +12,13 @@ products:
 
 # Kubernetes Environments
 
-The recommended OTel architecture for Kubernetes clusters includes a set of OpenTelemetry collectors in different modes. The following diagram shows the different modes:
+The recommended OTel architecture for Kubernetes clusters includes a set of OpenTelemetry collectors in different forms. The following diagram shows the different forms:
 
 ![K8s-Cluster](../images/arch-k8s-cluster.png)
 
-## Daemon mode
+## Daemon form
 
-The Collector in Daemon mode is deployed on each Kubernetes node to collect nodes-local logs and host metrics.
+The Collector in Daemon form is deployed on each Kubernetes node to collect nodes-local logs and host metrics.
 
 The daemon collector also receives telemetry from applications instrumented with OTel SDKs and running on corresponding nodes.
 
@@ -26,13 +26,13 @@ That Collector enriches the application telemetry with resource information such
 
 All data is then being sent through OTLP to the OTel or EDOT Gateway Collector.
 
-## Cluster mode
+## Cluster form
 
-The Collector in Cluster mode collects Kubernetes cluster-level metrics and sends them to the OTel or EDOT Gateway Collector using OTLP.
+The Collector in Cluster form collects Kubernetes cluster-level metrics and sends them to the OTel or EDOT Gateway Collector using OTLP.
 
-## Gateway mode
+## Gateway form
 
-The OTel or EDOT Collector in Gateway mode gathers the OTel data from all other collectors and ingests it into the Elastic backend.
+The OTel or EDOT Collector in Gateway form gathers the OTel data from all other collectors and ingests it into the Elastic backend.
 
 For self-managed and {{ech}} deployment models the Gateway Collector does some additional pre-processing of data.
 

--- a/docs/reference/edot-collector/modes.md
+++ b/docs/reference/edot-collector/modes.md
@@ -69,10 +69,10 @@ In Kubernetes environments, EDOT Collectors are typically deployed in three dist
 
 In Kubernetes, the Agent mode is implemented in two forms:
 
-| Mode | Deployment | Functions |
+| Form | Deployment | Functions |
 |------|------------|-----------|
-| Daemon mode | DaemonSet on every node | - Collects node-local logs and host metrics.<br>- Receives telemetry data from applications instrumented with OpenTelemetry SDKs running on the node.<br>- Enriches application telemetry data with resource information such as host and Kubernetes metadata.<br>- Forwards all data to the Gateway Collector using the OTLP protocol. |
-| Cluster mode | Centralized service | - Collects Kubernetes cluster-level metrics from the Kubernetes API.<br>- Monitors cluster-wide resources that aren't specific to individual nodes.<br>- Forwards collected data to the Gateway Collector using the OTLP protocol. |
+| Daemon form | DaemonSet on every node | - Collects node-local logs and host metrics.<br>- Receives telemetry data from applications instrumented with OpenTelemetry SDKs running on the node.<br>- Enriches application telemetry data with resource information such as host and Kubernetes metadata.<br>- Forwards all data to the Gateway Collector using the OTLP protocol. |
+| Cluster form | Centralized service | - Collects Kubernetes cluster-level metrics from the Kubernetes API.<br>- Monitors cluster-wide resources that aren't specific to individual nodes.<br>- Forwards collected data to the Gateway Collector using the OTLP protocol. |
 
 ### Gateway mode in Kubernetes
 


### PR DESCRIPTION
Renaming K8s modes to "forms" for clarity (and avoiding overlapping with other modes that are more important).