### PR TITLE
Note about declarative config

### DIFF
--- a/docs/reference/edot-sdks/java/configuration.md
+++ b/docs/reference/edot-sdks/java/configuration.md
@@ -13,6 +13,8 @@ products:
 
 # Configure the EDOT Java agent
 
+:::{note} [Declarative config](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#declarative-configuration) is not yet supported, and using it will disable many agent features :::
+
 The [minimal configuration](#minimal-configuration) section provides a recommended starting point for EDOT Java configuration.
 
 See [configuration options](#configuration-options) for details on the supported configuration options and [configuration methods](#configuration-methods) for how to provide them.


### PR DESCRIPTION
declarative config is still experimental but will shortly become stable for the Java SDK. It's not yet fully compatible with the upstream agent nor agent distributions, so I think this note is worth adding