### PR TITLE
Use relative links for images

### DIFF
--- a/docs/reference/architecture/hosts_vms.md
+++ b/docs/reference/architecture/hosts_vms.md
@@ -15,7 +15,7 @@ products:
 
 On host or virtual machine environments, deploy local, per-host OpenTelemetry Collector instances, here referred to as OTel Collector in Agent Mode.
 
-![VM-Edge](/reference/images/arch-vm-edge.png)
+![VM-Edge](../images/arch-vm-edge.png)
 
 These collectors have two main purposes:
 
@@ -34,7 +34,7 @@ Elastic's Observability solution is technically compatible with edge setups that
 
 {{serverless-full}} provides a [Managed OTLP Endpoint](/reference/motlp.md) for ingestion of OpenTelemetry data.
 
-![VM-Serverless](/reference/images/arch-vm-serverless.png)
+![VM-Serverless](../images/arch-vm-serverless.png)
 
 Users can send their OTel data from the edge setup in OTel-native format through OTLP without any additional requirements for self-managed preprocessing of data.
 
@@ -42,11 +42,11 @@ Users can send their OTel data from the edge setup in OTel-native format through
 
 As of Elastic Stack version 9.0 on {{ech}} (ECH), you need to run a self-hosted EDOT Collector in Gateway Mode to ingest OTel data from the edge setup in OTel-native format into the Elastic-hosted {{es}}.
 
-![VM-ECH](/reference/images/arch-vm-ech.png)
+![VM-ECH](../images/arch-vm-ech.png)
 
 The EDOT Collector in Gateway mode enriches and pre-aggregates the data for a seamless experience in the Elastic Observability solution before ingesting it directly into {{es}}.
 
-If required, users can build their custom, EDOT-like Collector 
+If required, users can build their custom, EDOT-like Collector
 [following these instructions](/reference/edot-collector/custom-collector.md).
 
 :::{note}
@@ -61,7 +61,7 @@ If self-managing an EDOT Gateway is not a valid option for you, refer to [Elasti
 
 In a self-managed deployment scenario, you need to host an EDOT Collector in Gateway mode that pre-processes and ingests OTel data from the edge setup into the self-managed Elastic Stack.
 
-![VM-self-managed](/reference/images/arch-vm-self-managed.png)
+![VM-self-managed](../images/arch-vm-self-managed.png)
 
 :::{note}
 Compared to [Elastic's classic ingestion paths](docs-content://solutions/observability/apm/use-opentelemetry-with-apm.md) for OTel data, with the EDOT Gateway Collector there is no need for an APM Server anymore.

--- a/docs/reference/architecture/k8s.md
+++ b/docs/reference/architecture/k8s.md
@@ -15,7 +15,7 @@ products:
 
 The recommended OTel architecture for Kubernetes clusters includes a set of OpenTelemetry collectors in different forms. The following diagram shows the different forms:
 
-![K8s-Cluster](/reference/images/arch-k8s-cluster.png)
+![K8s-Cluster](../images/arch-k8s-cluster.png)
 
 ## Daemon form
 
@@ -49,7 +49,7 @@ Elastic's Observability solution is technically compatible with setups that are 
 
 {{serverless-full}} provides a [Managed OTLP Endpoint](/reference/motlp.md) for ingestion of OpenTelemetry data.
 
-![K8s-Serverless](/reference/images/arch-k8s-serverless.png)
+![K8s-Serverless](../images/arch-k8s-serverless.png)
 
 For a Kubernetes setup, that means the Gateway Collector passes through the OTel data in native format using the OTLP protocol to the managed OTLP endpoint. There is no need for the Gateway Collector to do any Elastic-specific pre-processing.
 
@@ -57,9 +57,9 @@ For a Kubernetes setup, that means the Gateway Collector passes through the OTel
 
 With {{ech}} (ECH), OTel data is being directly ingested into the Elastic-hosted {{es}} instance.
 
-![K8s-ECH](/reference/images/arch-k8s-ech.png)
+![K8s-ECH](../images/arch-k8s-ech.png)
 
-The Gateway Collector needs to do some preprocessing, aggregation of metrics and, finally, it uses the {{es}} exporter to ingest data into ECH. 
+The Gateway Collector needs to do some preprocessing, aggregation of metrics and, finally, it uses the {{es}} exporter to ingest data into ECH.
 
 While the Daemon and Cluster collectors, as well as the OTel SDKs, can stay fully vendor agnostic or upstream, the Gateway Collector needs to be either an EDOT Collector or a [custom, EDOT-like Collector](/reference/edot-collector/custom-collector.md) containing the
 [required components and pre-processing pipelines](/reference/edot-collector/config/default-config-k8s.md#direct-ingestion-into-elasticsearch).
@@ -78,9 +78,9 @@ If self-managing an EDOT Gateway is not a valid option for you, refer to [Elasti
 
 With a self-managed scenario the Gateway Collector ingests data directly into the self-managed {{es}} instance.
 
-![K8s-self-managed](/reference/images/arch-k8s-self-managed.png)
+![K8s-self-managed](../images/arch-k8s-self-managed.png)
 
-The Gateway Collector does some preprocessing and aggregation of OTel data before ingesting it into {{es}}. 
+The Gateway Collector does some preprocessing and aggregation of OTel data before ingesting it into {{es}}.
 
 While the Daemon and Cluster collectors, as well as the OTel SDKs, can stay fully vendor agnostic or upstream, the Gateway Collector needs to be either an EDOT Collector or a [custom, EDOT-like Collector](/reference/edot-collector/custom-collector.md) containing the [required components and pre-processing pipelines](/reference/edot-collector/config/default-config-k8s.md#direct-ingestion-into-elasticsearch).
 

--- a/docs/reference/use-cases/kubernetes/index.md
+++ b/docs/reference/use-cases/kubernetes/index.md
@@ -18,15 +18,15 @@ products:
 The [quickstart guides](/reference/quickstart/index.md) for Kubernetes install a set of different EDOT Collectors and EDOT SDKs to cover collection of OpenTelemetry data for infrastructure monitoring, logs collection and application monitoring.
 
 The Kubernetes setup relies on the OpenTelemetry Operator, configured to automate orchestration of EDOT as follows:
- 
+
 * EDOT Collector Cluster: Collection of cluster metrics.
 * EDOT Collector Daemon: Collection of node metrics, logs, and application telemetry.
-* EDOT Collector Gateway: Preprocessing, aggregation, and ingestion of data into Elastic. 
+* EDOT Collector Gateway: Preprocessing, aggregation, and ingestion of data into Elastic.
 * EDOT SDKs: Annotated applications are auto-instrumented with [EDOT SDKs](/reference/edot-sdks/index.md).
 
 The following diagram summarizes the previous components and how they interact with Elastic:
-  
-![K8s-architecture](/reference/images/EDOT-K8s-architecture.png)
+
+![K8s-architecture](../../images/EDOT-K8s-architecture.png)
 
 Read on to learn how to:
 


### PR DESCRIPTION
In https://github.com/elastic/opentelemetry/pull/339, we started using absolute links (which I think is smart!), but we uncovered a bug where images are not rendered when using absolute links. This changes image links back to relative links until the bug can be investigated and fixed.

cc @elastic/docs-engineering @alexandra5000 