### PR TITLE
Add notes clarifying metadata behavior in default Collector config docs

### DIFF
--- a/docs/reference/edot-collector/config/default-config-k8s.md
+++ b/docs/reference/edot-collector/config/default-config-k8s.md
@@ -44,6 +44,12 @@ The [`filelog`] and [`hostmetrics`] receivers are used to gather container logs 
 
 Logs and metrics are batched for better performance ([`batch`] processor) and then enriched with meta information using the [`k8sattributes`], [`resourcedetection`] and [`resource`] processors.
 
+:::{note}
+The `from_context: client_metadata` option in the `resource` processor only applies to transport-level metadata. It cannot extract custom application attributes.  
+
+To propagate such values into your telemetry, set them explicitly in your application code using EDOT SDK instrumentation. For more information, refer to [EDOT Collector doesn’t propagate client metadata](docs-content://troubleshoot/ingest/opentelemetry/edot-collector/metadata.md).
+:::
+
 ### Application telemetry through OTLP from OTel SDKs
 
 The Daemonset collectors also receive the application telemetry from OTel SDKs that instrument services and pods running on corresponding Kubernetes nodes.

--- a/docs/reference/edot-collector/config/default-config-standalone.md
+++ b/docs/reference/edot-collector/config/default-config-standalone.md
@@ -53,6 +53,12 @@ The goal of EDOT is to preserve OTel data formats and semantics as much as possi
 
 For logs collection, the default configuration uses the [`filelog`] receiver to read log entries from files.  In addition, the [`resourcedetection`] processor enriches the log entries with metadata about the corresponding host and operating system.
 
+:::{note}
+The `from_context: client_metadata` option in the `resource` processor only applies to transport-level metadata. It cannot extract custom application attributes.  
+
+To propagate such values into your telemetry, set them explicitly in your application code using EDOT SDK instrumentation. For more information, refer to [EDOT Collector doesn’t propagate client metadata](docs-content://troubleshoot/ingest/opentelemetry/edot-collector/metadata.md).
+:::
+
 Data is exported directly to {{es}} using the [`elasticsearch`] exporter in `OTel-native` mode.
 
 #### Application and traces collection pipeline


### PR DESCRIPTION
Added a note to the standalone and Kubernetes default config pages to clarify that `from_context: client_metadata` only works with transport-level metadata (HTTP/gRPC headers), and cannot extract application-specific fields.

Related to [this troubleshooting topic](https://github.com/elastic/docs-content/pull/2057).