### PR TITLE
Add notes warning against using EDOT SDKs alongside other APM agents

### DIFF
--- a/docs/reference/edot-sdks/dotnet/setup/index.md
+++ b/docs/reference/edot-sdks/dotnet/setup/index.md
@@ -31,7 +31,7 @@ This quickstart guide documents the introductory steps required to set up OpenTe
 * [Zero code](/reference/edot-sdks/dotnet/setup/zero-code.md)
 
 :::{warning}
-Avoid using .NET SDK together with other APM agents, including agents from Elastic such as Elastic APM. Running multiple agents in the same application process may lead to conflicting instrumentation, duplicate telemetry, or other unexpected behavior.
+Avoid using the .NET SDK alongside any other APM agent, including Elastic APM agents. Running multiple agents in the same application process may lead to conflicting instrumentation, duplicate telemetry, or other unexpected behavior.
 :::
 
 ### Prerequisites

--- a/docs/reference/edot-sdks/index.md
+++ b/docs/reference/edot-sdks/index.md
@@ -48,7 +48,7 @@ This table provides an overview of the features available in the {{edot}} (EDOT)
 Elastic provides technical support for EDOT Language SDKs according to Elastic's [Support Policy](https://www.elastic.co/support_policy). EDOT SDKs are meant to be used in combination with the [EDOT Collector](/reference/edot-collector/index.md) or the [{{motlp}}](/reference/motlp.md) to ingest data into Elastic solutions from the EDOT SDKs. Other ingestion paths are not officially supported by Elastic.
 
 :::{warning}
-Avoid using EDOT SDKs together with other APM agents, including agents from Elastic such as Elastic APM. Running multiple agents in the same application process may lead to conflicting instrumentation, duplicate telemetry, or other unexpected behavior.
+Avoid using EDOT SDKs alongside any other APM agent, including Elastic APM agents. Running multiple agents in the same application process may lead to conflicting instrumentation, duplicate telemetry, or other unexpected behavior.
 :::
 
 ## License

--- a/docs/reference/edot-sdks/java/setup/index.md
+++ b/docs/reference/edot-sdks/java/setup/index.md
@@ -18,7 +18,7 @@ products:
 Learn how to set up the {{edot}} (EDOT) Java in various environments, including Kubernetes and others.
 
 :::{warning}
-Avoid using Java SDK together with other APM agents, including agents from Elastic such as Elastic APM. Running multiple agents in the same application process may lead to conflicting instrumentation, duplicate telemetry, or other unexpected behavior.
+Avoid using the Java SDK alongside any other APM agent, including Elastic APM agents. Running multiple agents in the same application process may lead to conflicting instrumentation, duplicate telemetry, or other unexpected behavior.
 :::
 
 ## Kubernetes

--- a/docs/reference/edot-sdks/nodejs/setup/index.md
+++ b/docs/reference/edot-sdks/nodejs/setup/index.md
@@ -32,7 +32,7 @@ export OTEL_SERVICE_NAME="my-app"
 node --import @elastic/opentelemetry-node my-app.js
 ```
 :::{warning}
-Avoid using Node.js SDK together with other APM agents, including agents from Elastic such as Elastic APM. Running multiple agents in the same application process may lead to conflicting instrumentation, duplicate telemetry, or other unexpected behavior.
+Avoid using the Node.js SDK alongside any other APM agent, including Elastic APM agents. Running multiple agents in the same application process may lead to conflicting instrumentation, duplicate telemetry, or other unexpected behavior.
 :::
 
 If you are deploying in Kubernetes, see the [Kubernetes setup guide](/reference/edot-sdks/nodejs/setup/k8s.md).

--- a/docs/reference/edot-sdks/php/setup/index.md
+++ b/docs/reference/edot-sdks/php/setup/index.md
@@ -28,7 +28,7 @@ To quickly get up and running, follow the [Elastic OpenTelemetry Quickstart guid
 - Exploring traces and metrics in {{kib}}.
 
 :::{warning}
-Avoid using PHP SDK together with other APM agents, including agents from Elastic such as Elastic APM. Running multiple agents in the same application process may lead to conflicting instrumentation, duplicate telemetry, or other unexpected behavior.
+Avoid using the PHP SDK alongside any other APM agent, including Elastic APM agents. Running multiple agents in the same application process may lead to conflicting instrumentation, duplicate telemetry, or other unexpected behavior.
 :::
 
 ### Operating system and PHP version

--- a/docs/reference/edot-sdks/python/setup/index.md
+++ b/docs/reference/edot-sdks/python/setup/index.md
@@ -20,7 +20,7 @@ Learn how to set up the {{edot}} (EDOT) Python in various environments, includin
 Follow these steps to get started.
 
 :::{warning}
-Avoid using Python SDK together with other APM agents, including agents from Elastic such as Elastic APM. Running multiple agents in the same application process may lead to conflicting instrumentation, duplicate telemetry, or other unexpected behavior.
+Avoid using the Python SDK alongside any other APM agent, including Elastic APM agents. Running multiple agents in the same application process may lead to conflicting instrumentation, duplicate telemetry, or other unexpected behavior.
 :::
 
 ::::::{stepper}


### PR DESCRIPTION
Added a warning note on the general EDOT SDK page and all individual SDK setup pages to caution users against running SDKs together with other APM agents.

Resolves part of [this issue](https://github.com/elastic/docs-content/issues/2025).