### PR TITLE
ci: move from dependabot reviewers to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
 *.md @theletterf @elastic/ingest-docs 
-/docs/ @theletterf @elastic/ingest-docs
-/.github/workflows @elastic/ingest-docs @elastic/observablt-ci
+/docs/ @theletterf @elastic/ingest-docs 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 *.md @theletterf @elastic/ingest-docs 
-/docs/ @theletterf @elastic/ingest-docs 
+/docs/ @theletterf @elastic/ingest-docs
+/.github/workflows @elastic/ingest-docs @elastic/observablt-ci

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,4 @@
 *.md @theletterf @elastic/ingest-docs 
 /docs/ @theletterf @elastic/ingest-docs 
+
+/.github/workflows @elastic/observablt-ci

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,2 @@
 *.md @theletterf @elastic/ingest-docs 
 /docs/ @theletterf @elastic/ingest-docs 
-
-/.github/workflows @elastic/observablt-ci

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,6 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "22:00"
-    reviewers:
-      - "elastic/observablt-ci"
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
Removed reviewers section in dependabot.yml and moved it's definition to CODEOWNERS.

Reviewers dependabot.yml configuration is being retired option because the functionality overlaps with [GitHub code owners](https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).
See: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/