### PR TITLE
Add link on the Compatibility and support landing page

### DIFF
--- a/docs/reference/compatibility/index.md
+++ b/docs/reference/compatibility/index.md
@@ -22,4 +22,5 @@ The following pages describe the compatibility and support levels for different 
 - [EDOT compared to upstream](edot-vs-upstream.md)
 - [Limitations](limitations.md)
 - [Nomenclature](nomenclature.md)
+- [Data streams comparison](data-streams.md)
 


### PR DESCRIPTION
Adds a link to the newly created [OpenTelemetry data streams compared to classic APM](https://www.elastic.co/docs/reference/opentelemetry/compatibility/data-streams) page.