### PR TITLE
Add EDOT Node.js docs for ELASTIC_OTEL_CONTEXT_PROPAGATION_ONLY and send_metrcs et al central config settings

### DIFF
--- a/docs/reference/edot-sdks/nodejs/configuration.md
+++ b/docs/reference/edot-sdks/nodejs/configuration.md
@@ -72,7 +72,7 @@ The 🔹 symbol denotes settings with a default value or behavior that differs b
 | `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` 🔹 | [(EDOT Ref)](#otel_exporter_otlp_metrics_temporality_preference-details) The metrics exporter's default aggregation `temporality`. The default value is `delta`. The upstream OTel default is `cumulative`. |
 | | |
 | `OTEL_SEMCONV_STABILITY_OPT_IN` 🔹 | [(EDOT Ref)](#otel_semconv_stability_opt_in-details) Control which HTTP semantic conventions are used by `@opentelemetry/instrumentation-http`. The default value is `http`. The upstream OTel default is an empty value. |
-| `ELASTIC_OTEL_CONTEXT_PROPAGATION_ONLY` 🔹 | [(EDOT Ref)](#elastic_otel_context_propagation_only-details) Set to `true` to enable trace-context propagation in outgoing requests and log correlation, but disable the sending of spans. |
+| `ELASTIC_OTEL_CONTEXT_PROPAGATION_ONLY` 🔹 | [(EDOT Ref)](#elastic_otel_context_propagation_only-details) Set to `true` to turn on trace-context propagation in outgoing requests and log correlation. This turns off the sending of spans. |
 | | |
 | `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | [(EDOT Ref)](#otel_instrumentation_genai_capture_message_content-details) A boolean to control whether message content should be included in GenAI-related telemetry. |
 | | |
@@ -243,10 +243,9 @@ product:
   edot_node: preview 1.3.0
 ```
 
-Set `ELASTIC_OTEL_CONTEXT_PROPAGATION_ONLY` to `true` to enable trace-context propagation in outgoing requests and log correlation, but disable the sending of spans.
-Setting `OTEL_TRACES_EXPORTER=none` will "win" over this setting: trace-context propagation will be disabled.
+Set the `ELASTIC_OTEL_CONTEXT_PROPAGATION_ONLY` environment variable to `true` to turn on trace-context propagation in outgoing requests and log correlation. This turns off the sending of spans. Setting `OTEL_TRACES_EXPORTER` to `none` overrides this setting, deactivating trace-context propagation.
 
-See the [migration guide](/reference/edot-sdks/nodejs/migration.md#contextpropagationonly) for details on how this relates to the similar `contextPropagationOnly` setting from the non-OTel Elastic Node.js APM agent.
+Refer to the [migration guide](/reference/edot-sdks/nodejs/migration.md#contextpropagationonly) for details on how this relates to the similar `contextPropagationOnly` setting from the non-OTel Elastic Node.js APM agent.
 
 ### `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` details [otel_instrumentation_genai_capture_message_content-details]
 

--- a/docs/reference/edot-sdks/nodejs/migration.md
+++ b/docs/reference/edot-sdks/nodejs/migration.md
@@ -148,16 +148,15 @@ The following table shows the equivalent values of log levels between `elastic-a
 
 ### `contextPropagationOnly`
 
-The equivalent of the Elastic APM Node.js agent [`contextPropagationOnly`](apm-agent-nodejs://reference/configuration.md#context-propagation-only) option can be accomplished with the following EDOT Node.js settings.
+The equivalent of the Elastic APM Node.js agent [`contextPropagationOnly`](apm-agent-nodejs://reference/configuration.md#context-propagation-only) option can be accomplished with the following EDOT Node.js settings:
 
-- [`ELASTIC_OTEL_CONTEXT_PROPAGATION_ONLY=true`](/reference/edot-sdks/nodejs/configuration.md#elastic_otel_context_propagation_only-details) to configure trace-context propagation, but disable sending spans and the overhead from doing so. Note that using `OTEL_TRACES_EXPORTER=none` will break this: there will be no context-propagation.
-  The `ELASTIC_OTEL_CONTEXT_PROPAGATION_ONLY` EDOT Node.js setting only impacts *tracing*, as opposed to the APM agent `contextPropagationOnly` which impacts both tracing and *metrics*.
-- If you would also like to disable metrics sending and collection overhead:
-    - [`OTEL_METRICS_EXPORTER=none`](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#exporter-selection) to disable the sending of any metrics
-    - [`ELASTIC_OTEL_HOST_METRICS_DISABLED=true`](/reference/edot-sdks/nodejs/configuration.md#elastic_otel_host_metrics_disabled-details) to disable any overhead from collection by the `@opentelemetry/host-metrics` package.
-    - [`OTEL_NODE_DISABLED_INSTRUMENTATIONS=runtime-node`](/reference/edot-sdks/nodejs/configuration.md#otel_node_disabledenabled_instrumentations-details) to disable collection overhead from the `@opentelemetry/instrumentation-runtime-node` instrumentation
+- [`ELASTIC_OTEL_CONTEXT_PROPAGATION_ONLY=true`](/reference/edot-sdks/nodejs/configuration.md#elastic_otel_context_propagation_only-details) to configure trace-context propagation. This turns off sending spans and the overhead from doing so. Note that using `OTEL_TRACES_EXPORTER=none` turns off context-propagation. The `ELASTIC_OTEL_CONTEXT_PROPAGATION_ONLY` EDOT Node.js setting only impacts tracing, as opposed to the APM agent `contextPropagationOnly` which impacts both tracing and metric collection.
+- To turn off metrics sending and collection overhead, use the following settings:
+    - [`OTEL_METRICS_EXPORTER=none`](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#exporter-selection) to turn off the sending of any metrics.
+    - [`ELASTIC_OTEL_HOST_METRICS_DISABLED=true`](/reference/edot-sdks/nodejs/configuration.md#elastic_otel_host_metrics_disabled-details) to remove the overhead from metrics collection by the `@opentelemetry/host-metrics` package.
+    - [`OTEL_NODE_DISABLED_INSTRUMENTATIONS=runtime-node`](/reference/edot-sdks/nodejs/configuration.md#otel_node_disabledenabled_instrumentations-details) to remove metrics collection overhead from the `@opentelemetry/instrumentation-runtime-node` instrumentation
 
-Altogether:
+For example:
 
 ```
 ELASTIC_OTEL_CONTEXT_PROPAGATION_ONLY=true


### PR DESCRIPTION
Refs: https://github.com/elastic/elastic-otel-node/issues/891

Still in draft until https://github.com/elastic/elastic-otel-node/pull/928 is ready and merged.