### PR TITLE
edot-sdks/python: update central configuration settings available

### DIFF
--- a/docs/reference/edot-sdks/python/configuration.md
+++ b/docs/reference/edot-sdks/python/configuration.md
@@ -60,9 +60,10 @@ To deactivate central configuration, remove the `ELASTIC_OTEL_OPAMP_ENDPOINT` en
 
 You can modify the following settings for EDOT Python through APM Agent Central Configuration:
 
-| Settings      | Description                                 | Type    |
-|--------------|---------------------------------------------|---------|
-| Logging level | Configure EDOT Python agent logging level. | Dynamic |
+| Settings      | Description                                  | Type    | Stack | EDOT Python |
+|---------------|----------------------------------------------|---------|-------|-------------|
+| Logging level | Configure EDOT Python agent logging level.   | Dynamic | 9.1   | 1.4.0       |
+| Sampling rate | Configure EDOT Python tracing sampling rate. | Dynamic | 9.2   | 1.7.0       |
 
 Dynamic settings can be changed without having to restart the application.
 


### PR DESCRIPTION
The central configuration chapter still contains the following annotation but I need a way to express the requirements per feature. What do you think?

```{applies_to}
serverless: unavailable
stack: preview 9.1 
product:
  edot_python: preview 1.4.0
```
