### PR TITLE
docs: update apmschema url to use apm-data

### DIFF
--- a/docs/reference/edot-collector/components/elasticapmintakereceiver.md
+++ b/docs/reference/edot-collector/components/elasticapmintakereceiver.md
@@ -15,7 +15,7 @@ products:
 
 # Elastic APM intake receiver
 
-The Elastic APM intake receiver is an OpenTelemetry Collector component that receives APM data from classic Elastic APM Agents. The receiver supports the [Elastic Intake v2 protocol](https://github.com/elastic/apm-server/tree/main/docs/spec/v2) and behaves like the Elastic APM Server, so that telemetry is stored in the same format and using the same indices while going through the Collector. This allows users of classic APM agents to gradually migrate to OpenTelemetry and adapt their instrumentation to the new OTel-based approach.
+The Elastic APM intake receiver is an OpenTelemetry Collector component that receives APM data from classic Elastic APM Agents. The receiver supports the [Elastic Intake v2 protocol](https://github.com/elastic/apm-data/tree/main/input/elasticapm/docs/spec/v2) and behaves like the Elastic APM Server, so that telemetry is stored in the same format and using the same indices while going through the Collector. This allows users of classic APM agents to gradually migrate to OpenTelemetry and adapt their instrumentation to the new OTel-based approach.
 
 :::{important}
 Real user monitoring (RUM) intake and older intake protocols are not supported.


### PR DESCRIPTION
apm schema was moved to apm-data a long time ago and the apm-server files are just a mirror

update the docs to use apm-data files to we can stop mirroring them in apm-server

Related to https://github.com/elastic/apm-server/issues/17707