### PR TITLE
Update ecf aws documentation structure and add cloudtrail log type

### DIFF
--- a/docs/reference/_snippets/find-motlp-endpoint.md
+++ b/docs/reference/_snippets/find-motlp-endpoint.md
@@ -1,0 +1,20 @@
+To retrieve your {{motlp}} endpoint address and API key, follow these steps:
+
+::::{applies-switch}
+:::{applies-item} serverless:
+1. In {{ecloud}}, create an Observability project or open an existing one.
+2. Go to **Add data**, select **Applications** and then select **OpenTelemetry**.
+3. Copy the endpoint and authentication headers values.
+
+Alternatively, you can retrieve the endpoint from the **Manage project** page and create an API key manually from the **API keys** page.
+:::
+
+:::{applies-item} ess:
+{applies_to}`stack: preview 9.2`
+1. In {{ecloud}}, create an {{ech}} deployment or open an existing one.
+2. Go to **Add data**, select **Applications** and then select **OpenTelemetry**.
+3. Copy the endpoint and authentication headers values.
+
+Alternatively, you can retrieve the endpoint from the **Manage project** page and create an API key manually from the **API keys** page.
+:::
+::::

--- a/docs/reference/edot-cloud-forwarder/azure.md
+++ b/docs/reference/edot-cloud-forwarder/azure.md
@@ -89,7 +89,7 @@ To find out the URL of the managed OTLP endpoint and the API key for authenticat
 
 ::::{dropdown} Steps to retrieve the OTLP endpoint and API key
 
-:::{include} ../_snippets/serverless-endpoint-api.md
+:::{include} ../_snippets/find-motlp-endpoint.md
 :::
 
 In the Bicep templates, the OTLP endpoint is set as `elasticsearchOtlpEndpoint`, and the API key is set as `elasticsearchApiKey`. 

--- a/docs/reference/motlp.md
+++ b/docs/reference/motlp.md
@@ -57,25 +57,7 @@ To send data to Elastic through the {{motlp}}, follow the [Send data to the Elas
 
 ### Find your {{motlp}} endpoint
 
-To retrieve your {{motlp}} endpoint address, follow these steps:
-
-::::{applies-switch}
-:::{applies-item} serverless:
-1. In {{ecloud}}, select the project name and then select **Manage project**.
-2. Locate the **Connection alias** and select **Edit**.
-3. Copy the Managed OTLP endpoint URL.
-:::
-
-:::{applies-item} ess:
-{applies_to}`stack: preview 9.2`
-1. In {{ecloud}}, select **Add data** and then select **Application: OpenTelemetry**
-2. Copy the Managed OTLP endpoint URL from `OTEL_EXPORTER_OTLP_ENDPOINT`. You can use this endpoint for both OpenTelemetry collectors and SDKs.
-:::
-::::
-
-:::{note}
-:applies_to: { ess:, stack: preview 9.2 }
-The Managed OTLP endpoint might not be available in all {{ech}} regions during the Technical Preview.
+:::{include} _snippets/find-motlp-endpoint.md
 :::
 
 ### Configure SDKs to send data directly


### PR DESCRIPTION
Changes of this PR: 

- Parameter descriptions: Updated descriptions of parameters with information on when to increase the defaults
- Default values: Emphasized its an outcome of extensive load testing
- Deployment structure: Added dedicated "Deployment options" section on top
- AWS CLI deployment: Added region guidance, moved template download, added stack update instructions
- Console deployment: Added quick deployment link, manual steps, update instructions, reorganized SAR
- Stack deletion: Split into CLI and Console options with separate instructions
- Monitoring: Added new section with CloudWatch Metrics Explorer and Logs guidance
- Kibana integration: Added CloudTrail Logs integration entry