### PR TITLE
Add ECH in preview tags to the EDOT Cloud Forwarder page

### DIFF
--- a/docs/reference/edot-cloud-forwarder/index.md
+++ b/docs/reference/edot-cloud-forwarder/index.md
@@ -4,6 +4,8 @@ description: Introduction to the EDOT Cloud Forwarder, the Elastic Distribution 
 applies_to:
   serverless:
     observability: preview
+  deployment:
+    ess: preview
 products:
   - id: cloud-serverless
   - id: observability


### PR DESCRIPTION
Making sure that the ECH preview availability on the [EDOT Cloud Forwarder](https://www.elastic.co/docs/reference/opentelemetry/edot-cloud-forwarder) page is visible.

This change ensure continuity with the updates in the [Compare Elastic Cloud Hosted and Serverless](https://www.elastic.co/docs/deploy-manage/deploy/elastic-cloud/differences-from-other-elasticsearch-offerings) page that compares various capabilities between ECH and Serverless. 

This change relates to https://github.com/elastic/opentelemetry/issues/491 and https://github.com/elastic/docs-content/issues/1198#issuecomment-2918112702