### PR TITLE
Mark the Central configuration for EDOT SDKs doc as unavailable on Serverless

### DIFF
--- a/docs/reference/central-configuration.md
+++ b/docs/reference/central-configuration.md
@@ -5,6 +5,7 @@ applies_to:
   deployment:
       ess: preview 9.1
   stack: preview 9.1
+  serverless: unavailable
 products:
   - id: observability
   - id: kibana


### PR DESCRIPTION
This PR marks the [Central configuration for EDOT SDKs](https://www.elastic.co/docs/reference/opentelemetry/central-configuration) doc as unavailable on Serverless (to match the statement we’re making in [Compare Elastic Cloud Hosted and Serverless](https://www.elastic.co/docs/deploy-manage/deploy/elastic-cloud/differences-from-other-elasticsearch-offerings)).