### PR TITLE
Remove edot-sdks index from reference toc - nav-v2 changes proposal

### DIFF
--- a/docs/reference/toc.yml
+++ b/docs/reference/toc.yml
@@ -22,4 +22,5 @@ toc:
   - toc: motlp
   - file: data-streams.md
   - file: central-configuration.md
+  - toc: edot-sdks
   - toc: edot-cloud-forwarder

--- a/docs/reference/toc.yml
+++ b/docs/reference/toc.yml
@@ -22,5 +22,4 @@ toc:
   - toc: motlp
   - file: data-streams.md
   - file: central-configuration.md
-  - file: edot-sdks/index.md
   - toc: edot-cloud-forwarder


### PR DESCRIPTION
The individual EDOT SDK tocs (Android, .NET, iOS, Java, Node.js, PHP, Python, Browser) are wired directly into the assembler navigation, so the edot-sdks/index.md entry in this toc causes them to appear twice in the nav sidebar — once under EDOT and once in the dedicated EDOT SDKs group defined in navigation-v2.yml.

Relates to https://github.com/elastic/docs-builder/pull/3024

Issue: https://github.com/elastic/docs-content/issues/5748