### PR TITLE
Add Browser to EDOT SDKs feature overview table

### DIFF
--- a/docs/reference/edot-sdks/features.yml
+++ b/docs/reference/edot-sdks/features.yml
@@ -23,6 +23,9 @@ features:
     iOS:
       status: ga
       min_version: 1.0
+    Browser:
+      status: tech-preview
+      min_version: 0.1.0
   - name: Service map
     link: docs-content://solutions/observability/apm/service-map.md
     is_sub_feature: true
@@ -48,6 +51,9 @@ features:
     iOS:
       status: ga
       min_version: v1.0
+    Browser:
+      status: tech-preview
+      min_version: 0.1.0
   - name: Zero-code instrumentation
     link: https://opentelemetry.io/docs/concepts/instrumentation/zero-code/
     min_stack_version:
@@ -69,10 +75,13 @@ features:
       min_version: 1.0
     Android:
       status: not-available
-      min_version: 
+      min_version:
     iOS:
       status: not-available
-      min_version: 
+      min_version:
+    Browser:
+      status: not-available
+      min_version:
   - name: Head-based sampling
     link: https://opentelemetry.io/docs/concepts/sampling/#head-sampling
     min_stack_version:
@@ -98,6 +107,9 @@ features:
     iOS:
       status: ga
       min_version: v1.0
+    Browser:
+      status: tech-preview
+      min_version: 0.1.0
   - name: Baggage
     link: https://opentelemetry.io/docs/concepts/signals/baggage/
     min_stack_version:
@@ -123,31 +135,37 @@ features:
     iOS:
       status: ga
       min_version: v1.0
+    Browser:
+      status: tech-preview
+      min_version: 0.1.0
   - name: Inferred spans
     link:
     min_stack_version:
     is_sub_feature: true
     .NET:
       status: not-available
-      min_version: 
+      min_version:
     Java:
       status: ga
       min_version: 1.0
     Node.js:
       status: not-available
-      min_version: 
+      min_version:
     PHP:
       status: tech-preview
       min_version: 1.0
     Python:
       status: not-available
-      min_version: 
+      min_version:
     Android:
       status: not-available
-      min_version: 
+      min_version:
     iOS:
       status: not-available
-      min_version: 
+      min_version:
+    Browser:
+      status: not-available
+      min_version:
   - name: Logs collection
     link: https://opentelemetry.io/docs/specs/otel/logs/#opentelemetry-solution
     min_stack_version:
@@ -172,6 +190,9 @@ features:
     iOS:
       status: ga
       min_version: v1.0
+    Browser:
+      status: tech-preview
+      min_version: 0.1.0
   - name: Logs correlation
     link: https://opentelemetry.io/docs/specs/otel/logs/#log-correlation
     is_sub_feature: true
@@ -197,6 +218,9 @@ features:
     iOS:
       status: ga
       min_version: v1.0
+    Browser:
+      status: tech-preview
+      min_version: 0.1.0
   - name: Metrics collection
     link: https://opentelemetry.io/docs/concepts/signals/metrics/
     min_stack_version:
@@ -221,6 +245,9 @@ features:
     iOS:
       status: tech-preview
       min_version: v0.7
+    Browser:
+      status: tech-preview
+      min_version: 0.1.0
   - name: Custom metrics
     link:
     is_sub_feature: true
@@ -246,31 +273,37 @@ features:
     iOS:
       status: tech-preview
       min_version: v0.7
+    Browser:
+      status: tech-preview
+      min_version: 0.1.0
   - name: Agent health monitoring
     link:
     is_sub_feature: true
     min_stack_version:
     .NET:
       status: not-available
-      min_version: 
+      min_version:
     Java:
       status: not-available
-      min_version: 
+      min_version:
     Node.js:
       status: not-available
-      min_version: 
+      min_version:
     PHP:
       status: not-available
       min_version:
     Python:
       status: not-available
-      min_version: 
+      min_version:
     Android:
       status: not-available
-      min_version: 
+      min_version:
     iOS:
       status: not-available
-      min_version: 
+      min_version:
+    Browser:
+      status: not-available
+      min_version:
   - name: Runtime metrics
     link: https://opentelemetry.io/docs/specs/semconv/runtime/
     is_sub_feature: true
@@ -292,13 +325,16 @@ features:
       min_version:
     Python:
       status: not-available
-      min_version: 
+      min_version:
     Android:
       status: not-available
-      min_version: 
+      min_version:
     iOS:
       status: not-available
-      min_version: 
+      min_version:
+    Browser:
+      status: not-applicable
+      min_version:
   - name: Capturing errors / exceptions
     link:
     min_stack_version:
@@ -323,37 +359,43 @@ features:
     iOS:
       status: ga
       min_version: v1.0
+    Browser:
+      status: tech-preview
+      min_version: 0.1.0
   - name: Crash reporting
     link:
     is_sub_feature: true
     min_stack_version:
     .NET:
       status: not-applicable
-      min_version: 
+      min_version:
     Java:
       status: not-applicable
-      min_version: 
+      min_version:
     Node.js:
       status: not-applicable
-      min_version: 
+      min_version:
     PHP:
       status: not-applicable
-      min_version: 
+      min_version:
     Python:
       status: not-applicable
-      min_version: 
+      min_version:
     Android:
       status: not-available
-      min_version: 
+      min_version:
     iOS:
       status: ga
       min_version: v1.0
+    Browser:
+      status: not-applicable
+      min_version:
   - name: Central configuration
     link:
     min_stack_version:
     .NET:
       status: not-available
-      min_version: 
+      min_version:
     Java:
       status: tech-preview
       min_version: 1.5.0
@@ -372,28 +414,34 @@ features:
     iOS:
       status: tech-preview
       min_version: 1.4.0
+    Browser:
+      status: not-available
+      min_version:
   - name: Profiling integration
     link:
     min_stack_version:
     .NET:
       status: not-available
-      min_version: 
+      min_version:
     Java:
       status: tech-preview
       min_version: 1.0
     Node.js:
       status: not-available
-      min_version: 
+      min_version:
     PHP:
       status: not-available
-      min_version: 
+      min_version:
     Python:
       status: not-available
-      min_version: 
+      min_version:
     Android:
       status: not-available
-      min_version: 
+      min_version:
     iOS:
+      status: not-available
+      min_version:
+    Browser:
       status: not-available
       min_version:
   - name: TLS for OTLP endpoint
@@ -422,6 +470,9 @@ features:
       status: ga
       min_version: v1.0
       notes: CA-signed certificates only
+    Browser:
+      status: tech-preview
+      min_version: 0.1.0
   - name: TLS for OpAMP endpoint
     link:
     is_sub_feature: true
@@ -449,3 +500,6 @@ features:
       status: ga
       min_version: v1.4.0
       notes: CA-signed certificates only
+    Browser:
+      status: not-available
+      min_version:

--- a/docs/reference/edot-sdks/index.md
+++ b/docs/reference/edot-sdks/index.md
@@ -40,26 +40,26 @@ This table provides an overview of the features available in the {{edot}} (EDOT)
 
 % start:edot-features
 
-| Feature | .NET | Java | Node.js | PHP | Python | Android | iOS |
-| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
-| **[Distributed tracing](https://opentelemetry.io/docs/concepts/signals/traces/)** | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | 
-| [Service map](docs-content://solutions/observability/apm/service-map.md) | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ v1.0+ | 
-| [Zero-code instrumentation](https://opentelemetry.io/docs/concepts/instrumentation/zero-code/) | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ❌  | ❌  | 
-| [Head-based sampling](https://opentelemetry.io/docs/concepts/sampling/#head-sampling) | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.1+ | ✅ v1.0+ | 
-| [Baggage](https://opentelemetry.io/docs/concepts/signals/baggage/) | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ❌  | ✅ v1.0+ | 
-| Inferred spans | ❌  | ✅ 1.0+ | ❌  | 𝐓 1.0+ | ❌  | ❌  | ❌  | 
-| **[Logs collection](https://opentelemetry.io/docs/specs/otel/logs/#opentelemetry-solution)** | ✅ 1.0+ | ✅ 1.0+ | 𝐓 1.0+ | ✅ 1.0+ | 𝐓 1.0+ | ✅ 1.0+ | ✅ v1.0+ | 
-| [Logs correlation](https://opentelemetry.io/docs/specs/otel/logs/#log-correlation) | ✅ 1.0+ | ✅ 1.0+ | 𝐓 1.0+ | ✅ 1.0+ | 𝐓 1.0+ | ✅ 1.0+ | ✅ v1.0+ | 
-| **[Metrics collection](https://opentelemetry.io/docs/concepts/signals/metrics/)** | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | 𝐓 v0.7+ | 
-| Custom metrics | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | 𝐓 v0.7+ | 
-| Agent health monitoring | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | 
-| [Runtime metrics](https://opentelemetry.io/docs/specs/semconv/runtime/) | ✅ 1.0+[^1] | ✅ 1.0+[^1] | 𝐓 1.0+[^1] | ❌  | ❌  | ❌  | ❌  | 
-| **Capturing errors / exceptions** | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ v1.0+ | 
-| Crash reporting | ➖  | ➖  | ➖  | ➖  | ➖  | ❌  | ✅ v1.0+ | 
-| **Central configuration** | ❌  | 𝐓 1.5.0+ | 𝐓 1.2.0+ | 𝐓 1.1.0+ | 𝐓 1.4.0+ | 𝐓 1.2.0+ | 𝐓 1.4.0+ | 
-| **Profiling integration** | ❌  | 𝐓 1.0+ | ❌  | ❌  | ❌  | ❌  | ❌  | 
-| **[TLS for OTLP endpoint](https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp)** | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.6+ | ✅ 1.2+ | ✅ 1.0+ | ✅ 1.0+[^2] | ✅ v1.0+[^2] | 
-| TLS for OpAMP endpoint | ❌  | ❌  | ✅ 1.7.0+ | ✅ 1.2.0+ | ✅ 1.10.0+ | ✅ 1.2.0+[^2] | ✅ v1.4.0+[^2] | 
+| Feature | .NET | Java | Node.js | PHP | Python | Android | iOS | Browser |
+| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| **[Distributed tracing](https://opentelemetry.io/docs/concepts/signals/traces/)** | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | 𝐓 0.1.0+ | 
+| [Service map](docs-content://solutions/observability/apm/service-map.md) | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ v1.0+ | 𝐓 0.1.0+ | 
+| [Zero-code instrumentation](https://opentelemetry.io/docs/concepts/instrumentation/zero-code/) | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ❌  | ❌  | ❌  | 
+| [Head-based sampling](https://opentelemetry.io/docs/concepts/sampling/#head-sampling) | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.1+ | ✅ v1.0+ | 𝐓 0.1.0+ | 
+| [Baggage](https://opentelemetry.io/docs/concepts/signals/baggage/) | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ❌  | ✅ v1.0+ | 𝐓 0.1.0+ | 
+| Inferred spans | ❌  | ✅ 1.0+ | ❌  | 𝐓 1.0+ | ❌  | ❌  | ❌  | ❌  | 
+| **[Logs collection](https://opentelemetry.io/docs/specs/otel/logs/#opentelemetry-solution)** | ✅ 1.0+ | ✅ 1.0+ | 𝐓 1.0+ | ✅ 1.0+ | 𝐓 1.0+ | ✅ 1.0+ | ✅ v1.0+ | 𝐓 0.1.0+ | 
+| [Logs correlation](https://opentelemetry.io/docs/specs/otel/logs/#log-correlation) | ✅ 1.0+ | ✅ 1.0+ | 𝐓 1.0+ | ✅ 1.0+ | 𝐓 1.0+ | ✅ 1.0+ | ✅ v1.0+ | 𝐓 0.1.0+ | 
+| **[Metrics collection](https://opentelemetry.io/docs/concepts/signals/metrics/)** | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | 𝐓 v0.7+ | 𝐓 0.1.0+ | 
+| Custom metrics | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | 𝐓 v0.7+ | 𝐓 0.1.0+ | 
+| Agent health monitoring | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | 
+| [Runtime metrics](https://opentelemetry.io/docs/specs/semconv/runtime/) | ✅ 1.0+[^1] | ✅ 1.0+[^1] | 𝐓 1.0+[^1] | ❌  | ❌  | ❌  | ❌  | ➖  | 
+| **Capturing errors / exceptions** | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ v1.0+ | 𝐓 0.1.0+ | 
+| Crash reporting | ➖  | ➖  | ➖  | ➖  | ➖  | ❌  | ✅ v1.0+ | ➖  | 
+| **Central configuration** | ❌  | 𝐓 1.5.0+ | 𝐓 1.2.0+ | 𝐓 1.1.0+ | 𝐓 1.4.0+ | 𝐓 1.2.0+ | 𝐓 1.4.0+ | ❌  | 
+| **Profiling integration** | ❌  | 𝐓 1.0+ | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | 
+| **[TLS for OTLP endpoint](https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp)** | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.6+ | ✅ 1.2+ | ✅ 1.0+ | ✅ 1.0+[^2] | ✅ v1.0+[^2] | 𝐓 0.1.0+ | 
+| TLS for OpAMP endpoint | ❌  | ❌  | ✅ 1.7.0+ | ✅ 1.2.0+ | ✅ 1.10.0+ | ✅ 1.2.0+[^2] | ✅ v1.4.0+[^2] | ❌  | 
 
 **Legend:**
 

--- a/scripts/templates/features.jinja2
+++ b/scripts/templates/features.jinja2
@@ -21,7 +21,7 @@
 {%- set unique_notes = {} -%}
 {%- set note_counter = namespace(value=1) -%}
 {%- for feature in features -%}
-{%- for lang in [".NET", "Java", "Node.js", "PHP", "Python", "Android", "iOS"] -%}
+{%- for lang in [".NET", "Java", "Node.js", "PHP", "Python", "Android", "iOS", "Browser"] -%}
 {%- if feature[lang]['notes'] is defined and feature[lang]['notes'] -%}
 {%- if feature[lang]['notes'] not in unique_notes -%}
 {%- set _ = unique_notes.update({feature[lang]['notes']: note_counter.value}) -%}
@@ -31,10 +31,10 @@
 {%- endfor -%}
 {%- endfor -%}
 
-| Feature | .NET | Java | Node.js | PHP | Python | Android | iOS |
-| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| Feature | .NET | Java | Node.js | PHP | Python | Android | iOS | Browser |
+| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
 {%- for feature in features %}
-| {% if feature.is_sub_feature %}{{ title(feature) }}{% else %}**{{ title(feature) }}**{% endif %} | {% for lang in [".NET", "Java", "Node.js", "PHP", "Python", "Android", "iOS"] %}{{ icon(feature[lang]['status']) }} {% if feature[lang]['min_version'] %}{{ feature[lang]['min_version'] }}+{% endif %}{% if feature[lang]['notes'] is defined and feature[lang]['notes'] %}[^{{ unique_notes[feature[lang]['notes']] }}]{% endif %} | {% endfor %}
+| {% if feature.is_sub_feature %}{{ title(feature) }}{% else %}**{{ title(feature) }}**{% endif %} | {% for lang in [".NET", "Java", "Node.js", "PHP", "Python", "Android", "iOS", "Browser"] %}{{ icon(feature[lang]['status']) }} {% if feature[lang]['min_version'] %}{{ feature[lang]['min_version'] }}+{% endif %}{% if feature[lang]['notes'] is defined and feature[lang]['notes'] %}[^{{ unique_notes[feature[lang]['notes']] }}]{% endif %} | {% endfor %}
 {%- endfor %}
 
 **Legend:**


### PR DESCRIPTION
## Summary

- Adds Browser column to `features.yml` and the Jinja2 template
- Re-runs `scripts/tools.py` to regenerate the table in `docs/reference/edot-sdks/index.md`
- All Browser features marked `tech-preview` at `0.1.0+`; runtime metrics and crash reporting are not-applicable; zero-code instrumentation, central config, profiling, and OpAMP TLS are not-available

Relates to elastic/docs-content#5933

Closes https://github.com/elastic/docs-content/issues/6112

🤖 Generated with [Claude Code](https://claude.com/claude-code)