### PR TITLE
Add Authentication section to mOTLP reference: APM application privileges required

### DIFF
--- a/docs/reference/motlp/index.md
+++ b/docs/reference/motlp/index.md
@@ -75,6 +75,30 @@ You can also set the `OTEL_RESOURCE_ATTRIBUTES` environment variable to set the 
 export OTEL_RESOURCE_ATTRIBUTES="data_stream.dataset=app.orders"
 ```
 
+## Authentication
+
+The {{motlp}} authenticates requests using {{product.apm}} application privileges. To send data to the endpoint, your API key must include the `event:write` privilege for the `apm` application:
+
+```json
+{
+  "otlp_writer": {
+    "applications": [
+      {
+        "application": "apm",
+        "resources": ["*"],
+        "privileges": ["event:write"]
+      }
+    ]
+  }
+}
+```
+
+For step-by-step instructions on generating an API key, refer to the [Send data to the {{motlp}}](docs-content://solutions/observability/get-started/quickstart-elastic-cloud-otel-endpoint.md) quickstart.
+
+:::{note}
+Index-level privilege scoping is not yet supported for the {{motlp}}. API keys restricted to specific index-level privileges will return a `PermissionDenied` error. Support for index-level privilege scoping is planned for a future release.
+:::
+
 ## OTLP client configuration
 
 When using OpenTelemetry collectors to send data to the {{motlp}}, configure the OTLP exporter to leverage an in-memory queue and optimized batching defaults. This improves throughput, minimizes data loss, and maintains low end-to-end latency.

--- a/docs/reference/motlp/index.md
+++ b/docs/reference/motlp/index.md
@@ -96,7 +96,7 @@ The {{motlp}} authenticates requests using {{product.apm}} application privilege
 For step-by-step instructions on generating an API key, refer to the [Send data to the {{motlp}}](docs-content://solutions/observability/get-started/quickstart-elastic-cloud-otel-endpoint.md) quickstart.
 
 :::{note}
-Index-level privilege scoping is not yet supported for the {{motlp}}. API keys restricted to specific index-level privileges will return a `PermissionDenied` error. Support for index-level privilege scoping is planned for a future release.
+Index-level privilege scoping is not yet supported for the {{motlp}}. API keys restricted to specific index-level privileges return a `PermissionDenied` error.
 :::
 
 ## OTLP client configuration


### PR DESCRIPTION
## Summary

Adds a new `## Authentication` section to the mOTLP reference page documenting the current API key privilege requirements and a known limitation around index-level scoping.

Changes:
- New section between "Send data" and "OTLP client configuration" showing the minimum role descriptor (`event:write` for the `apm` application)
- Note that index-level privilege scoping is not yet supported — users who try custom index privileges will hit `PermissionDenied`
- Cross-link to the quickstart for step-by-step API key creation instructions

Related: elastic/docs-content#6233

🤖 Generated with [Claude Code](https://claude.com/claude-code)