### PR TITLE
Add EDOT .NET to central config docs and features table

### DIFF
--- a/docs/reference/central-configuration.md
+++ b/docs/reference/central-configuration.md
@@ -33,7 +33,7 @@ Each EDOT SDK contains an embedded OpAMP Client. Following the Open Agent Manage
 
 To use {{product.apm-agent}} Central Configuration for EDOT SDKs, you need:
 
-* An Elastic self-managed or {{ecloud}} deployment, version 9.1 or higher.
+* An Elastic self-managed or {{ecloud}} deployment, version 9.1 or later.
 * A standalone [EDOT Collector](elastic-agent://reference/edot-collector/index.md), in either Agent or Collector mode.
 * EDOT SDKs instrumenting your application.
 
@@ -41,15 +41,15 @@ The following versions of EDOT and {{stack}} support central configuration:
 
 | Component | Minimum version |
 |-----------|----------------|
-| {{kib}} | 9.1 or higher |
-| EDOT Collector | 8.19, 9.1 or higher |
-| EDOT Android | 1.2.0 or higher |
-| EDOT iOS | 1.4.0 or higher |
-| EDOT Java | 1.5.0 or higher |
-| EDOT .NET | 1.4.0 or higher |
-| EDOT Node.js | 1.2.0 or higher |
-| EDOT PHP | 1.1.1 or higher |
-| EDOT Python | 1.4.0 or higher |
+| {{kib}} | 9.1 or later |
+| EDOT Collector | 8.19, 9.1 or later |
+| EDOT Android | 1.2.0 or later |
+| EDOT iOS | 1.4.0 or later |
+| EDOT Java | 1.5.0 or later |
+| EDOT .NET | 1.4.0 or later |
+| EDOT Node.js | 1.2.0 or later |
+| EDOT PHP | 1.1.1 or later |
+| EDOT Python | 1.4.0 or later |
 
 ::::{note}
 Serverless deployments are not currently supported.

--- a/docs/reference/central-configuration.md
+++ b/docs/reference/central-configuration.md
@@ -203,7 +203,7 @@ For a list of settings that you can configure through {{product.apm-agent}} Cent
 - [EDOT Android](apm-agent-android://reference/edot-android/configuration.md#central-configuration)
 - [EDOT iOS](apm-agent-ios://reference/edot-ios/configuration.md#central-configuration-edot)
 - [EDOT Java](elastic-otel-java://reference/edot-java/configuration.md#central-configuration)
-- [EDOT .NET](elastic-otel-dotnet://reference/edot-dotnet/configuration.md#central-configuration)
+- [EDOT .NET](elastic-otel-dotnet://reference/edot-dotnet/configuration.md)
 - [EDOT Node.js](elastic-otel-node://reference/edot-node/configuration.md#central-configuration)
 - [EDOT PHP](elastic-otel-php://reference/edot-php/configuration.md#central-configuration)
 - [EDOT Python](elastic-otel-python://reference/edot-python/configuration.md#central-configuration)

--- a/docs/reference/central-configuration.md
+++ b/docs/reference/central-configuration.md
@@ -46,6 +46,7 @@ The following versions of EDOT and {{stack}} support central configuration:
 | EDOT Android | 1.2.0 or higher |
 | EDOT iOS | 1.4.0 or higher |
 | EDOT Java | 1.5.0 or higher |
+| EDOT .NET | 1.4.0 or higher |
 | EDOT Node.js | 1.2.0 or higher |
 | EDOT PHP | 1.1.1 or higher |
 | EDOT Python | 1.4.0 or higher |
@@ -202,6 +203,7 @@ For a list of settings that you can configure through {{product.apm-agent}} Cent
 - [EDOT Android](apm-agent-android://reference/edot-android/configuration.md#central-configuration)
 - [EDOT iOS](apm-agent-ios://reference/edot-ios/configuration.md#central-configuration-edot)
 - [EDOT Java](elastic-otel-java://reference/edot-java/configuration.md#central-configuration)
+- [EDOT .NET](elastic-otel-dotnet://reference/edot-dotnet/configuration.md#central-configuration)
 - [EDOT Node.js](elastic-otel-node://reference/edot-node/configuration.md#central-configuration)
 - [EDOT PHP](elastic-otel-php://reference/edot-php/configuration.md#central-configuration)
 - [EDOT Python](elastic-otel-python://reference/edot-python/configuration.md#central-configuration)

--- a/docs/reference/edot-sdks/features.yml
+++ b/docs/reference/edot-sdks/features.yml
@@ -394,8 +394,8 @@ features:
     link:
     min_stack_version:
     .NET:
-      status: not-available
-      min_version:
+      status: tech-preview
+      min_version: 1.4.0
     Java:
       status: tech-preview
       min_version: 1.5.0
@@ -478,8 +478,9 @@ features:
     is_sub_feature: true
     min_stack_version:
     .NET:
-      status: not-available
-      min_version:
+      status: tech-preview
+      min_version: 1.4.0
+      notes: Custom certificate verification and mTLS are not available yet.
     Java:
       status: not-available
       min_version:

--- a/docs/reference/edot-sdks/index.md
+++ b/docs/reference/edot-sdks/index.md
@@ -56,10 +56,10 @@ This table provides an overview of the features available in the {{edot}} (EDOT)
 | [Runtime metrics](https://opentelemetry.io/docs/specs/semconv/runtime/) | ✅ 1.0+[^1] | ✅ 1.0+[^1] | 𝐓 1.0+[^1] | ❌  | ❌  | ❌  | ❌  | ➖  | 
 | **Capturing errors / exceptions** | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.0+ | ✅ v1.0+ | 𝐓 0.1.0+ | 
 | Crash reporting | ➖  | ➖  | ➖  | ➖  | ➖  | ❌  | ✅ v1.0+ | ➖  | 
-| **Central configuration** | ❌  | 𝐓 1.5.0+ | 𝐓 1.2.0+ | 𝐓 1.1.0+ | 𝐓 1.4.0+ | 𝐓 1.2.0+ | 𝐓 1.4.0+ | ❌  | 
+| **Central configuration** | 𝐓 1.4.0+ | 𝐓 1.5.0+ | 𝐓 1.2.0+ | 𝐓 1.1.0+ | 𝐓 1.4.0+ | 𝐓 1.2.0+ | 𝐓 1.4.0+ | ❌  | 
 | **Profiling integration** | ❌  | 𝐓 1.0+ | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | 
 | **[TLS for OTLP endpoint](https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp)** | ✅ 1.0+ | ✅ 1.0+ | ✅ 1.6+ | ✅ 1.2+ | ✅ 1.0+ | ✅ 1.0+[^2] | ✅ v1.0+[^2] | 𝐓 0.1.0+ | 
-| TLS for OpAMP endpoint | ❌  | ❌  | ✅ 1.7.0+ | ✅ 1.2.0+ | ✅ 1.10.0+ | ✅ 1.2.0+[^2] | ✅ v1.4.0+[^2] | ❌  | 
+| TLS for OpAMP endpoint | 𝐓 1.4.0+[^3] | ❌  | ✅ 1.7.0+ | ✅ 1.2.0+ | ✅ 1.10.0+ | ✅ 1.2.0+[^2] | ✅ v1.4.0+[^2] | ❌  | 
 
 **Legend:**
 
@@ -72,6 +72,8 @@ This table provides an overview of the features available in the {{edot}} (EDOT)
 [^1]: Runtime metrics can be ingested but visualization in the APM Service > Metrics tab is currently limited.
 
 [^2]: CA-signed certificates only
+
+[^3]: Custom certificate verification and mTLS aren't available yet.
 
 % end:edot-features
 


### PR DESCRIPTION
## Summary

- Adds EDOT .NET 1.4.0 to the prerequisites table in the central configuration reference
- Adds EDOT .NET to the supported settings links in the central configuration reference
- Updates the SDK features table: central configuration and TLS for OpAMP endpoint now show tech-preview (1.4.0+) for .NET

Closes https://github.com/elastic/docs-content/issues/6333

Related: https://github.com/elastic/elastic-otel-dotnet/pull/411


🤖 Generated with [Claude Code](https://claude.com/claude-code)