### PR TITLE
mOTLP: data_stream override for telemetry signals

### DIFF
--- a/docs/reference/motlp/index.md
+++ b/docs/reference/motlp/index.md
@@ -56,9 +56,9 @@ export OTEL_EXPORTER_OTLP_ENDPOINT="https://<motlp-endpoint>"
 export OTEL_EXPORTER_OTLP_HEADERS="Authorization=ApiKey <key>"
 ```
 
-### Routing logs to dedicated datasets
+### Routing telemetry to dedicated datasets or namespace
 
-You can route logs to dedicated datasets by setting the `data_stream.dataset` attribute on the log record. This attribute is used to route the log to the corresponding dataset.
+You can route signals to dedicated datasets by setting the `data_stream.dataset` attribute on the record. This attribute is used to route the signal to the corresponding dataset.
 
 For example, if you want to route the {{edot-cf}} logs to custom datasets, you can add the following attributes to the log records:
 
@@ -74,6 +74,16 @@ You can also set the `OTEL_RESOURCE_ATTRIBUTES` environment variable to set the 
 ```bash
 export OTEL_RESOURCE_ATTRIBUTES="data_stream.dataset=app.orders"
 ```
+
+The  `data_stream.namespace` attributes is also honored for all signals — logs, metrics, and traces.
+
+:::{important}
+Any `data_stream.dataset` or `data_stream.namespace` resource attribute present in an OTLP payload overrides mOTLP's default routing for that signal. This applies whether the attribute is set intentionally or by a collector, SDK, or integration.
+
+If data is landing in an unexpected data stream, inspect a sample document from that data stream for the field `resource.attributes.data_stream.dataset`. If the field is present and matches the unexpected data stream name, the attribute was set in the payload — not by the pipeline.
+
+To restore default routing, remove the `data_stream.dataset` and `data_stream.namespace` resource attributes from your OTLP payload configuration. Once removed, mOTLP falls back to routing based on `service.name`.
+:::
 
 ## Authentication
 

--- a/docs/reference/motlp/index.md
+++ b/docs/reference/motlp/index.md
@@ -75,12 +75,12 @@ You can also set the `OTEL_RESOURCE_ATTRIBUTES` environment variable to set the 
 export OTEL_RESOURCE_ATTRIBUTES="data_stream.dataset=app.orders"
 ```
 
-The  `data_stream.namespace` attributes is also honored for all signals — logs, metrics, and traces.
+The  `data_stream.namespace` attributes is also honored for all signals: logs, metrics, and traces.
 
 :::{important}
 Any `data_stream.dataset` or `data_stream.namespace` resource attribute present in an OTLP payload overrides mOTLP's default routing for that signal. This applies whether the attribute is set intentionally or by a collector, SDK, or integration.
 
-If data is landing in an unexpected data stream, inspect a sample document from that data stream for the field `resource.attributes.data_stream.dataset`. If the field is present and matches the unexpected data stream name, the attribute was set in the payload — not by the pipeline.
+If data is landing in an unexpected data stream, inspect a sample document from that data stream for the field `resource.attributes.data_stream.dataset`. If the field is present and matches the unexpected data stream name, the attribute was set in the payload, not by the pipeline.
 
 To restore default routing, remove the `data_stream.dataset` and `data_stream.namespace` resource attributes from your OTLP payload configuration. Once removed, mOTLP falls back to routing based on `service.name`.
 :::


### PR DESCRIPTION
Update the section on changing dataset for logs to all telemetry, as this is supported for all signals.

And add warning about unintentional data_stream attribute injection.
