### PR TITLE
Sync docs sweep workflow callers

### DIFF
--- a/.github/workflows/docs-applies-to-sweep.yml
+++ b/.github/workflows/docs-applies-to-sweep.yml
@@ -1,0 +1,47 @@
+name: Docs applies_to sweep
+on:
+  workflow_dispatch:
+    inputs:
+      source-repo:
+        description: "Repository to scan (owner/repo). Leave empty to scan this repo."
+        required: false
+        default: ""
+      docs-root:
+        description: "Root directory to sweep"
+        required: false
+        default: "docs"
+      target-path:
+        description: "Optional docs-root-relative directory to sweep recursively (accepts a leading slash)"
+        required: false
+        default: ""
+      scope-mode:
+        description: "How to scope the matched markdown files: auto, full, or shard"
+        required: false
+        default: "auto"
+      target-batch-size:
+        description: "Approximate pages per rotating slice"
+        required: false
+        default: "100"
+      max-per-fix-issue:
+        description: "Cap on findings per fix-issue"
+        required: false
+        default: "20"
+
+permissions:
+  actions: read
+  copilot-requests: write
+  contents: read
+  discussions: write
+  issues: write
+  pull-requests: read
+
+jobs:
+  run:
+    uses: elastic/docs-actions/.github/workflows/gh-aw-docs-applies-to-sweep.lock.yml@v1
+    with:
+      source-repo: ${{ inputs.source-repo }}
+      docs-root: ${{ inputs.docs-root }}
+      target-path: ${{ inputs.target-path }}
+      scope-mode: ${{ inputs.scope-mode }}
+      target-batch-size: ${{ inputs.target-batch-size }}
+      max-per-fix-issue: ${{ inputs.max-per-fix-issue }}

--- a/.github/workflows/docs-coherence-sweep.yml
+++ b/.github/workflows/docs-coherence-sweep.yml
@@ -1,0 +1,47 @@
+name: Docs coherence sweep
+on:
+  workflow_dispatch:
+    inputs:
+      source-repo:
+        description: "Repository to scan (owner/repo). Leave empty to scan this repo."
+        required: false
+        default: ""
+      docs-root:
+        description: "Root directory to sweep"
+        required: false
+        default: "docs"
+      target-path:
+        description: "Optional docs-root-relative directory to sweep recursively (accepts a leading slash)"
+        required: false
+        default: ""
+      scope-mode:
+        description: "How to scope the matched markdown files: auto, full, or shard"
+        required: false
+        default: "auto"
+      target-batch-size:
+        description: "Pages per rotating slice (smaller because coherence is expensive)"
+        required: false
+        default: "50"
+      max-per-fix-issue:
+        description: "Cap on findings per fix-issue"
+        required: false
+        default: "20"
+
+permissions:
+  actions: read
+  copilot-requests: write
+  contents: read
+  discussions: write
+  issues: write
+  pull-requests: read
+
+jobs:
+  run:
+    uses: elastic/docs-actions/.github/workflows/gh-aw-docs-coherence-sweep.lock.yml@v1
+    with:
+      source-repo: ${{ inputs.source-repo }}
+      docs-root: ${{ inputs.docs-root }}
+      target-path: ${{ inputs.target-path }}
+      scope-mode: ${{ inputs.scope-mode }}
+      target-batch-size: ${{ inputs.target-batch-size }}
+      max-per-fix-issue: ${{ inputs.max-per-fix-issue }}

--- a/.github/workflows/docs-frontmatter-sweep.yml
+++ b/.github/workflows/docs-frontmatter-sweep.yml
@@ -1,0 +1,47 @@
+name: Docs frontmatter sweep
+on:
+  workflow_dispatch:
+    inputs:
+      source-repo:
+        description: "Repository to scan (owner/repo). Leave empty to scan this repo."
+        required: false
+        default: ""
+      docs-root:
+        description: "Root directory to sweep"
+        required: false
+        default: "docs"
+      target-path:
+        description: "Optional docs-root-relative directory to sweep recursively (accepts a leading slash)"
+        required: false
+        default: ""
+      scope-mode:
+        description: "How to scope the matched markdown files: auto, full, or shard"
+        required: false
+        default: "auto"
+      target-batch-size:
+        description: "Approximate pages per rotating slice"
+        required: false
+        default: "100"
+      max-per-fix-issue:
+        description: "Cap on findings per fix-issue"
+        required: false
+        default: "20"
+
+permissions:
+  actions: read
+  copilot-requests: write
+  contents: read
+  discussions: write
+  issues: write
+  pull-requests: read
+
+jobs:
+  run:
+    uses: elastic/docs-actions/.github/workflows/gh-aw-docs-frontmatter-sweep.lock.yml@v1
+    with:
+      source-repo: ${{ inputs.source-repo }}
+      docs-root: ${{ inputs.docs-root }}
+      target-path: ${{ inputs.target-path }}
+      scope-mode: ${{ inputs.scope-mode }}
+      target-batch-size: ${{ inputs.target-batch-size }}
+      max-per-fix-issue: ${{ inputs.max-per-fix-issue }}

--- a/.github/workflows/docs-openings-sweep.yml
+++ b/.github/workflows/docs-openings-sweep.yml
@@ -1,0 +1,47 @@
+name: Docs page openings sweep
+on:
+  workflow_dispatch:
+    inputs:
+      source-repo:
+        description: "Repository to scan (owner/repo). Leave empty to scan this repo."
+        required: false
+        default: ""
+      docs-root:
+        description: "Root directory to sweep"
+        required: false
+        default: "docs"
+      target-path:
+        description: "Optional docs-root-relative directory to sweep recursively (accepts a leading slash)"
+        required: false
+        default: ""
+      scope-mode:
+        description: "How to scope the matched markdown files: auto, full, or shard"
+        required: false
+        default: "auto"
+      target-batch-size:
+        description: "Approximate pages per rotating slice"
+        required: false
+        default: "100"
+      max-per-fix-issue:
+        description: "Cap on findings per fix-issue"
+        required: false
+        default: "20"
+
+permissions:
+  actions: read
+  copilot-requests: write
+  contents: read
+  discussions: write
+  issues: write
+  pull-requests: read
+
+jobs:
+  run:
+    uses: elastic/docs-actions/.github/workflows/gh-aw-docs-openings-sweep.lock.yml@v1
+    with:
+      source-repo: ${{ inputs.source-repo }}
+      docs-root: ${{ inputs.docs-root }}
+      target-path: ${{ inputs.target-path }}
+      scope-mode: ${{ inputs.scope-mode }}
+      target-batch-size: ${{ inputs.target-batch-size }}
+      max-per-fix-issue: ${{ inputs.max-per-fix-issue }}

--- a/.github/workflows/docs-quality-sweep.yml
+++ b/.github/workflows/docs-quality-sweep.yml
@@ -1,0 +1,75 @@
+name: Docs quality sweep
+# Master dispatcher. Fans out to seven independent sub-workflows via
+# `gh workflow run`. We cannot use `workflow_call` here because gh-aw
+# v0.71.x compiles a single artifact prefix per orchestrator run
+# (github.workflow + github.run_id), which collides across reusable
+# workflow_call invocations and silently feeds every agent the same
+# prompt. Tracked upstream as github/gh-aw#30338.
+#
+# Kept thin on purpose: only the common "run all" knobs are exposed
+# here. To tune per-sweep settings (target-batch-size,
+# max-per-fix-issue, codespell-args, stale-content thresholds, and
+# coherence batch size), dispatch the relevant sub-workflow directly.
+
+on:
+  workflow_dispatch:
+    inputs:
+      sweeps:
+        description: "Sweeps to dispatch (comma-separated): frontmatter,applies-to,openings,style,typos,staleness,coherence, or 'all'"
+        required: false
+        default: "all"
+      source-repo:
+        description: "Repository to scan (owner/repo). Leave empty to scan this repo."
+        required: false
+        default: ""
+      docs-root:
+        description: "Root directory in the source repo"
+        required: false
+        default: "docs"
+      target-path:
+        description: "Optional docs-root-relative directory to sweep recursively (accepts a leading slash)"
+        required: false
+        default: ""
+      scope-mode:
+        description: "How to scope the matched markdown files: auto, full, or shard"
+        required: false
+        default: "auto"
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  fan-out:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch selected sweeps
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SWEEPS: ${{ inputs.sweeps }}
+          SRC: ${{ inputs.source-repo }}
+          ROOT: ${{ inputs.docs-root }}
+          TARGET_PATH: ${{ inputs.target-path }}
+          SCOPE_MODE: ${{ inputs.scope-mode }}
+        run: |
+          set -e
+          want() { [[ "$SWEEPS" == "all" || "$SWEEPS" == *"$1"* ]]; }
+
+          fire() {
+            local name="$1"
+            want "$name" || { echo "  skip $name (not in sweeps='$SWEEPS')"; return; }
+            echo "Dispatching docs-${name}-sweep.yml"
+            gh workflow run "docs-${name}-sweep.yml" --repo "${{ github.repository }}" \
+              -f source-repo="$SRC" \
+              -f docs-root="$ROOT" \
+              -f target-path="$TARGET_PATH" \
+              -f scope-mode="$SCOPE_MODE"
+          }
+
+          for n in frontmatter applies-to openings style typos staleness coherence; do
+            fire "$n"
+          done
+
+          echo ""
+          echo "Each dispatched sweep runs as its own workflow run. See the Actions tab."
+          echo "To tune per-sweep settings, dispatch the sub-workflow directly."

--- a/.github/workflows/docs-staleness-sweep.yml
+++ b/.github/workflows/docs-staleness-sweep.yml
@@ -1,0 +1,52 @@
+name: Docs staleness sweep
+on:
+  workflow_dispatch:
+    inputs:
+      source-repo:
+        description: "Repository to scan (owner/repo). Leave empty to scan this repo."
+        required: false
+        default: ""
+      docs-root:
+        description: "Root directory to sweep"
+        required: false
+        default: "docs"
+      target-path:
+        description: "Optional docs-root-relative directory to sweep recursively (accepts a leading slash)"
+        required: false
+        default: ""
+      scope-mode:
+        description: "How to scope the matched markdown files: auto, full, or shard"
+        required: false
+        default: "auto"
+      target-batch-size:
+        description: "Approximate pages per rotating slice"
+        required: false
+        default: "100"
+      max-per-fix-issue:
+        description: "Cap on findings per fix-issue"
+        required: false
+        default: "30"
+      stale-content-months:
+        description: "Flag pages whose latest commit is older than this many months"
+        required: false
+        default: "24"
+
+permissions:
+  actions: read
+  copilot-requests: write
+  contents: read
+  discussions: write
+  issues: write
+  pull-requests: read
+
+jobs:
+  run:
+    uses: elastic/docs-actions/.github/workflows/gh-aw-docs-staleness-sweep.lock.yml@v1
+    with:
+      source-repo: ${{ inputs.source-repo }}
+      docs-root: ${{ inputs.docs-root }}
+      target-path: ${{ inputs.target-path }}
+      scope-mode: ${{ inputs.scope-mode }}
+      target-batch-size: ${{ inputs.target-batch-size }}
+      max-per-fix-issue: ${{ inputs.max-per-fix-issue }}
+      stale-content-months: ${{ inputs.stale-content-months }}

--- a/.github/workflows/docs-style-sweep.yml
+++ b/.github/workflows/docs-style-sweep.yml
@@ -1,0 +1,47 @@
+name: Docs style sweep
+on:
+  workflow_dispatch:
+    inputs:
+      source-repo:
+        description: "Repository to scan (owner/repo). Leave empty to scan this repo."
+        required: false
+        default: ""
+      docs-root:
+        description: "Root directory to sweep"
+        required: false
+        default: "docs"
+      target-path:
+        description: "Optional docs-root-relative directory to sweep recursively (accepts a leading slash)"
+        required: false
+        default: ""
+      scope-mode:
+        description: "How to scope the matched markdown files: auto, full, or shard"
+        required: false
+        default: "auto"
+      target-batch-size:
+        description: "Approximate pages per rotating slice"
+        required: false
+        default: "100"
+      max-per-fix-issue:
+        description: "Cap on findings per fix-issue"
+        required: false
+        default: "20"
+
+permissions:
+  actions: read
+  copilot-requests: write
+  contents: read
+  discussions: write
+  issues: write
+  pull-requests: read
+
+jobs:
+  run:
+    uses: elastic/docs-actions/.github/workflows/gh-aw-docs-style-sweep.lock.yml@v1
+    with:
+      source-repo: ${{ inputs.source-repo }}
+      docs-root: ${{ inputs.docs-root }}
+      target-path: ${{ inputs.target-path }}
+      scope-mode: ${{ inputs.scope-mode }}
+      target-batch-size: ${{ inputs.target-batch-size }}
+      max-per-fix-issue: ${{ inputs.max-per-fix-issue }}

--- a/.github/workflows/docs-typos-sweep.yml
+++ b/.github/workflows/docs-typos-sweep.yml
@@ -1,0 +1,52 @@
+name: Docs typos sweep
+on:
+  workflow_dispatch:
+    inputs:
+      source-repo:
+        description: "Repository to scan (owner/repo). Leave empty to scan this repo."
+        required: false
+        default: ""
+      docs-root:
+        description: "Root directory to scan"
+        required: false
+        default: "docs"
+      target-path:
+        description: "Optional docs-root-relative directory to scan recursively (accepts a leading slash)"
+        required: false
+        default: ""
+      scope-mode:
+        description: "How to scope the matched markdown files: auto, full, or shard"
+        required: false
+        default: "auto"
+      target-batch-size:
+        description: "Approximate pages per rotating slice when scope-mode=shard"
+        required: false
+        default: "100"
+      max-per-fix-issue:
+        description: "Cap on findings per fix-issue (ignored; typos sweep emits all findings up to issue body limit)"
+        required: false
+        default: "20"
+      codespell-args:
+        description: "Extra codespell flags (e.g., --ignore-words=allowlist.txt --skip='*.svg')"
+        required: false
+        default: ""
+
+permissions:
+  actions: read
+  copilot-requests: write
+  contents: read
+  discussions: write
+  issues: write
+  pull-requests: read
+
+jobs:
+  run:
+    uses: elastic/docs-actions/.github/workflows/gh-aw-docs-typos-sweep.lock.yml@v1
+    with:
+      source-repo: ${{ inputs.source-repo }}
+      docs-root: ${{ inputs.docs-root }}
+      target-path: ${{ inputs.target-path }}
+      scope-mode: ${{ inputs.scope-mode }}
+      target-batch-size: ${{ inputs.target-batch-size }}
+      max-per-fix-issue: ${{ inputs.max-per-fix-issue }}
+      codespell-args: ${{ inputs.codespell-args }}


### PR DESCRIPTION
## Summary
- Add docs quality sweep caller workflows from docs-content.
- Wire the individual sweep callers to the locked reusable workflows in elastic/docs-actions.
- Default workflow_dispatch docs-root inputs to docs for this repository.

## Test plan
- Parsed the added workflow YAML files with Ruby YAML.
- Ran actionlint; it reports the existing unsupported copilot-requests permission scope, matching the current agentic workflow callers in this repo.


Made with [Cursor](https://cursor.com)