### PR TITLE
Add Prometheus Remote Write via mOTLP reference page

### DIFF
--- a/docs/reference/motlp/prometheus-remote-write.md
+++ b/docs/reference/motlp/prometheus-remote-write.md
@@ -22,7 +22,7 @@ Managed Inputs is the recommended ingestion path for all {{ecloud}} deployments.
 - The same Prometheus-to-TSDS mapping as the native {{es}} PRW endpoint.
 
 :::{warning}
-Sending PRW metrics directly to the [{{es}} Prometheus remote write endpoint](docs-content://manage-data/data-store/data-streams/tsds-ingest-prometheus-remote-write.md) bypasses Managed Inputs and is not recommended for {{ecloud}} deployments ({{serverless-full}} and {{ech}}). Direct ingest uses different authentication, has no buffering, and skips any processing before data reaches {{es}}. Use direct ingest only for self-managed deployments where Managed Inputs is not available.
+Sending PRW metrics directly to the [{{es}} Prometheus remote write endpoint](docs-content://manage-data/data-store/data-streams/tsds-ingest-prometheus-remote-write.md) bypasses Managed Inputs and is not recommended for {{serverless-full}} projects. Direct ingest uses different authentication, has no buffering, and skips any processing before data reaches {{es}}. Use direct ingest only for self-managed deployments where Managed Inputs is not available. {{ech}} support for the Managed Prometheus Remote Write endpoint is planned.
 :::
 
 ## Prerequisites
@@ -31,6 +31,8 @@ Sending PRW metrics directly to the [{{es}} Prometheus remote write endpoint](do
 - A Managed Inputs API key with the `event:write` privilege for the `apm` application. Refer to [Authentication](index.md#authentication) for the required key format and generation steps.
 
 ## Send Prometheus metrics through Managed Inputs
+
+Follow these steps to configure Prometheus to send metrics to the Managed Prometheus Remote Write endpoint.
 
 ::::::{stepper}
 
@@ -51,7 +53,7 @@ To find `<managed-inputs-endpoint>`:
 1. Log in to the {{ecloud}} Console.
 2. Find your project and select **Manage**.
 3. In the **Application endpoints, cluster and component IDs** section, select **Ingest**.
-4. Copy the endpoint value and append `/api/v1/write`.
+4. Copy the endpoint value and append `/api/v1/write`. For example: `https://<your-endpoint>.apm.elastic.cloud/api/v1/write`
 
 :::::
 

--- a/docs/reference/motlp/prometheus-remote-write.md
+++ b/docs/reference/motlp/prometheus-remote-write.md
@@ -15,13 +15,15 @@ products:
 
 ## When to use PRW using {{motlp}}
 
-Use PRW using {{motlp}} when you are already sending other telemetry (logs, traces, or OTLP metrics) through {{motlp}}. This approach gives you:
+{{motlp}} is the recommended ingestion path for {{serverless-full}} projects. Use it as your default when sending Prometheus metrics to Elastic. It provides:
 
 - A single API key and ingest endpoint for all telemetry signals.
 - Durable buffering, back-pressure, and retry on `429 Too Many Requests`.
 - The same Prometheus-to-TSDS mapping as the native {{es}} PRW endpoint.
 
-If you only need to ingest Prometheus metrics and do not use {{motlp}} for other signals, you can send directly to the [{{es}} Prometheus remote write endpoint](docs-content://manage-data/data-store/data-streams/tsds-ingest-prometheus-remote-write.md) instead.
+:::{warning}
+Sending PRW metrics directly to the [{{es}} Prometheus remote write endpoint](docs-content://manage-data/data-store/data-streams/tsds-ingest-prometheus-remote-write.md) bypasses {{motlp}} and is not recommended for {{serverless-full}} projects. Direct ingest uses different authentication, has no buffering, and removes the ability to apply processing to your data before it reaches {{es}}.
+:::
 
 ## Prerequisites
 

--- a/docs/reference/motlp/prometheus-remote-write.md
+++ b/docs/reference/motlp/prometheus-remote-write.md
@@ -13,7 +13,7 @@ products:
 
 Managed Inputs supports ingesting metrics sent in the [Prometheus Remote Write v1](https://prometheus.io/docs/specs/remote_write_spec/) (PRW) protocol. Metrics flow through the same Kafka-backed pipeline as OTLP data and land in {{es}} time series data streams (TSDS), producing the same result as sending PRW directly to {{es}}.
 
-## When to use PRW via Managed Inputs
+## When to use PRW with Managed Inputs
 
 Managed Inputs is the recommended ingestion path for all {{ecloud}} deployments. Use the Managed Prometheus Remote Write endpoint as your default when sending Prometheus metrics to {{serverless-full}} projects. It provides:
 

--- a/docs/reference/motlp/prometheus-remote-write.md
+++ b/docs/reference/motlp/prometheus-remote-write.md
@@ -93,6 +93,6 @@ Prometheus labels are mapped as TSDS dimensions in {{es}}, and metric types are 
 
 ## Limitations
 
-- URL-path routing (for example, `/_prometheus/metrics/{dataset}/api/v1/write`) to custom data streams is not supported through Managed Inputs. Use label-based routing instead.
+- URL-path routing (for example, `/_prometheus/metrics/{dataset}/api/v1/write`) to custom data streams is not supported through Managed Inputs. Use [label-based routing](docs-content://manage-data/data-store/data-streams/tsds-ingest-prometheus-remote-write.md#route-by-labels) instead.
 - Available on {{serverless-full}} only.
 - Samples with non-finite values (NaN, Infinity) are silently dropped by {{es}}, and staleness markers are not supported.

--- a/docs/reference/motlp/prometheus-remote-write.md
+++ b/docs/reference/motlp/prometheus-remote-write.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: "Prometheus Remote Write"
-description: "Ingest Prometheus metrics into Elasticsearch using the Prometheus Remote Write protocol through the Elastic Cloud Managed OTLP Endpoint."
+description: "Ingest Prometheus metrics into Elasticsearch using the Prometheus Remote Write protocol through Elastic Managed Inputs."
 applies_to:
   serverless:
     observability: ga
@@ -9,28 +9,28 @@ products:
   - id: observability
 ---
 
-# Ingest Prometheus metrics with {{motlp}} [prometheus-remote-write]
+# Ingest Prometheus metrics with Managed Inputs [prometheus-remote-write]
 
-{{motlp}} supports ingesting metrics sent in the [Prometheus Remote Write v1](https://prometheus.io/docs/specs/remote_write_spec/) (PRW) protocol. Metrics flow through the same Kafka-backed pipeline as OTLP data and land in {{es}} time series data streams (TSDS), producing the same result as sending PRW directly to {{es}}.
+Managed Inputs supports ingesting metrics sent in the [Prometheus Remote Write v1](https://prometheus.io/docs/specs/remote_write_spec/) (PRW) protocol. Metrics flow through the same Kafka-backed pipeline as OTLP data and land in {{es}} time series data streams (TSDS), producing the same result as sending PRW directly to {{es}}.
 
-## When to use PRW using {{motlp}}
+## When to use PRW via Managed Inputs
 
-{{motlp}} is the recommended ingestion path for {{serverless-full}} projects. Use it as your default when sending Prometheus metrics to Elastic. It provides:
+Managed Inputs is the recommended ingestion path for all {{ecloud}} deployments. Use the Managed Prometheus Remote Write endpoint as your default when sending Prometheus metrics to {{serverless-full}} or {{ech}} projects. It provides:
 
 - A single API key and ingest endpoint for all telemetry signals.
 - Durable buffering, back-pressure, and retry on `429 Too Many Requests`.
 - The same Prometheus-to-TSDS mapping as the native {{es}} PRW endpoint.
 
 :::{warning}
-Sending PRW metrics directly to the [{{es}} Prometheus remote write endpoint](docs-content://manage-data/data-store/data-streams/tsds-ingest-prometheus-remote-write.md) bypasses {{motlp}} and is not recommended for {{serverless-full}} projects. Direct ingest uses different authentication, has no buffering, and removes the ability to apply processing to your data before it reaches {{es}}.
+Sending PRW metrics directly to the [{{es}} Prometheus remote write endpoint](docs-content://manage-data/data-store/data-streams/tsds-ingest-prometheus-remote-write.md) bypasses Managed Inputs and is not recommended for {{ecloud}} deployments ({{serverless-full}} and {{ech}}). Direct ingest uses different authentication, has no buffering, and skips any processing before data reaches {{es}}. Use direct ingest only for self-managed deployments where Managed Inputs is not available.
 :::
 
 ## Prerequisites
 
 - An {{serverless-full}} Observability project.
-- A {{motlp}} API key with the `event:write` privilege for the `apm` application. Refer to [Authentication](index.md#authentication) for the required key format and generation steps.
+- A Managed Inputs API key with the `event:write` privilege for the `apm` application. Refer to [Authentication](index.md#authentication) for the required key format and generation steps.
 
-## Send Prometheus metrics through {{motlp}}
+## Send Prometheus metrics through Managed Inputs
 
 ::::::{stepper}
 
@@ -40,13 +40,13 @@ Add a `remote_write` entry to your Prometheus configuration:
 
 ```yaml
 remote_write:
-  - url: https://<motlp-endpoint>/api/v1/write
+  - url: https://<managed-inputs-endpoint>/api/v1/write
     authorization:
       type: ApiKey
       credentials: <api-key>
 ```
 
-To find `<motlp-endpoint>`:
+To find `<managed-inputs-endpoint>`:
 
 1. Log in to the {{ecloud}} Console.
 2. Find your project and select **Manage**.
@@ -72,7 +72,7 @@ In Prometheus, use `write_relabel_configs` to add these labels to every time ser
 
 ```yaml
 remote_write:
-  - url: https://<motlp-endpoint>/api/v1/write
+  - url: https://<managed-inputs-endpoint>/api/v1/write
     authorization:
       type: ApiKey
       credentials: <api-key>
@@ -94,6 +94,6 @@ Prometheus labels are mapped as TSDS dimensions in {{es}}, and metric types are 
 ## Limitations
 
 - Only Prometheus Remote Write v1 is supported. PRW v2 is not supported.
-- URL-path routing (for example, `/_prometheus/metrics/{dataset}/api/v1/write`) to custom data streams is not supported through {{motlp}}. Use label-based routing instead.
+- URL-path routing (for example, `/_prometheus/metrics/{dataset}/api/v1/write`) to custom data streams is not supported through Managed Inputs. Use label-based routing instead.
 - Available on {{serverless-full}} only.
 - Samples with non-finite values (NaN, Infinity) are silently dropped by {{es}}, and staleness markers are not supported.

--- a/docs/reference/motlp/prometheus-remote-write.md
+++ b/docs/reference/motlp/prometheus-remote-write.md
@@ -93,7 +93,6 @@ Prometheus labels are mapped as TSDS dimensions in {{es}}, and metric types are 
 
 ## Limitations
 
-- Only Prometheus Remote Write v1 is supported. PRW v2 is not supported.
 - URL-path routing (for example, `/_prometheus/metrics/{dataset}/api/v1/write`) to custom data streams is not supported through Managed Inputs. Use label-based routing instead.
 - Available on {{serverless-full}} only.
 - Samples with non-finite values (NaN, Infinity) are silently dropped by {{es}}, and staleness markers are not supported.

--- a/docs/reference/motlp/prometheus-remote-write.md
+++ b/docs/reference/motlp/prometheus-remote-write.md
@@ -15,7 +15,7 @@ Managed Inputs supports ingesting metrics sent in the [Prometheus Remote Write v
 
 ## When to use PRW via Managed Inputs
 
-Managed Inputs is the recommended ingestion path for all {{ecloud}} deployments. Use the Managed Prometheus Remote Write endpoint as your default when sending Prometheus metrics to {{serverless-full}} or {{ech}} projects. It provides:
+Managed Inputs is the recommended ingestion path for all {{ecloud}} deployments. Use the Managed Prometheus Remote Write endpoint as your default when sending Prometheus metrics to {{serverless-full}} projects. It provides:
 
 - A single API key and ingest endpoint for all telemetry signals.
 - Durable buffering, back-pressure, and retry on `429 Too Many Requests`.

--- a/docs/reference/motlp/prometheus-remote-write.md
+++ b/docs/reference/motlp/prometheus-remote-write.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: "Prometheus Remote Write"
-description: "Ingest Prometheus metrics into Elasticsearch using the Prometheus Remote Write protocol through Elastic Managed Inputs."
+description: "Ingest Prometheus metrics into Elasticsearch using the Prometheus Remote Write protocol through the Elastic Cloud Managed Prometheus Remote Write Endpoint."
 applies_to:
   serverless:
     observability: ga

--- a/docs/reference/motlp/prometheus-remote-write.md
+++ b/docs/reference/motlp/prometheus-remote-write.md
@@ -1,0 +1,97 @@
+---
+navigation_title: "Prometheus Remote Write"
+description: "Ingest Prometheus metrics into Elasticsearch using the Prometheus Remote Write protocol through the Elastic Cloud Managed OTLP Endpoint."
+applies_to:
+  serverless:
+    observability: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+---
+
+# Ingest Prometheus metrics with {{motlp}} [prometheus-remote-write]
+
+{{motlp}} supports ingesting metrics sent in the [Prometheus Remote Write v1](https://prometheus.io/docs/specs/remote_write_spec/) (PRW) protocol. Metrics flow through the same Kafka-backed pipeline as OTLP data and land in {{es}} time series data streams (TSDS), producing the same result as sending PRW directly to {{es}}.
+
+## When to use PRW using {{motlp}}
+
+Use PRW using {{motlp}} when you are already sending other telemetry (logs, traces, or OTLP metrics) through {{motlp}}. This approach gives you:
+
+- A single API key and ingest endpoint for all telemetry signals.
+- Durable buffering, back-pressure, and retry on `429 Too Many Requests`.
+- The same Prometheus-to-TSDS mapping as the native {{es}} PRW endpoint.
+
+If you only need to ingest Prometheus metrics and do not use {{motlp}} for other signals, you can send directly to the [{{es}} Prometheus remote write endpoint](docs-content://manage-data/data-store/data-streams/tsds-ingest-prometheus-remote-write.md) instead.
+
+## Prerequisites
+
+- An {{serverless-full}} Observability project.
+- A {{motlp}} API key with the `event:write` privilege for the `apm` application. Refer to [Authentication](index.md#authentication) for the required key format and generation steps.
+
+## Send Prometheus metrics through {{motlp}}
+
+::::::{stepper}
+
+:::::{step} Configure Prometheus
+
+Add a `remote_write` entry to your Prometheus configuration:
+
+```yaml
+remote_write:
+  - url: https://<motlp-endpoint>/api/v1/write
+    authorization:
+      type: ApiKey
+      credentials: <api-key>
+```
+
+To find `<motlp-endpoint>`:
+
+1. Log in to the {{ecloud}} Console.
+2. Find your project and select **Manage**.
+3. In the **Application endpoints, cluster and component IDs** section, select **Ingest**.
+4. Copy the endpoint value and append `/api/v1/write`.
+
+:::::
+
+:::::{step} Route metrics to custom data streams
+
+By default, all PRW metrics land in `metrics-generic.prometheus-default`.
+
+To route to a custom data stream, attach the `data_stream_dataset` and `data_stream_namespace` labels to your time series:
+
+| Label | Sets | Example |
+| --- | --- | --- |
+| `data_stream_dataset` | Dataset component of the data stream name | `myapp` |
+| `data_stream_namespace` | Namespace component of the data stream name | `production` |
+
+A time series with `data_stream_dataset: myapp` and `data_stream_namespace: production` routes to `metrics-myapp.prometheus-production`.
+
+In Prometheus, use `write_relabel_configs` to add these labels to every time series sent to a `remote_write` target:
+
+```yaml
+remote_write:
+  - url: https://<motlp-endpoint>/api/v1/write
+    authorization:
+      type: ApiKey
+      credentials: <api-key>
+    write_relabel_configs:
+      - target_label: data_stream_dataset
+        replacement: myapp
+      - target_label: data_stream_namespace
+        replacement: production
+```
+
+:::::
+
+::::::
+
+## How Prometheus data appears in {{es}}
+
+Prometheus labels are mapped as TSDS dimensions in {{es}}, and metric types are inferred from naming conventions. For details on the full mapping behavior, refer to the [{{es}} Prometheus remote write endpoint](docs-content://manage-data/data-store/data-streams/tsds-ingest-prometheus-remote-write.md) documentation.
+
+## Limitations
+
+- Only Prometheus Remote Write v1 is supported. PRW v2 is not supported.
+- URL-path routing (for example, `/_prometheus/metrics/{dataset}/api/v1/write`) to custom data streams is not supported through {{motlp}}. Use label-based routing instead.
+- Available on {{serverless-full}} only.
+- Samples with non-finite values (NaN, Infinity) are silently dropped by {{es}}, and staleness markers are not supported.

--- a/docs/reference/motlp/toc.yml
+++ b/docs/reference/motlp/toc.yml
@@ -1,4 +1,5 @@
 toc:
   - file: index.md
+  - file: prometheus-remote-write.md
   - file: rate-limiting.md
   - file: troubleshooting.md


### PR DESCRIPTION
## Summary

Adds a new reference page documenting how to ingest Prometheus metrics through the Elastic Cloud Managed OTLP Endpoint (mOTLP) using the Prometheus Remote Write (PRW) v1 protocol.

Closes https://github.com/elastic/hosted-otel-collector/issues/3205

## Generative AI disclosure

Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes
- [ ] No

If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).
Tool(s) and model(s) used: Claude Opus 4.8

Made with [Cursor](https://cursor.com)