### PR TITLE
Group mOTLP Endpoint docs and Prometheus Remote Write docs under Managed inputs

### DIFF
--- a/docs/redirects.yml
+++ b/docs/redirects.yml
@@ -4,8 +4,8 @@ redirects:
   'reference/edot-cloud-forwarder/azure/index.md': 'edot-cloud-forwarder-azure://reference/edot-cf-azure/index.md'
   'reference/edot-cloud-forwarder/gcp.md': 'reference/edot-cloud-forwarder/gcp/index.md'
 
-  # Managed OTLP Endpoint (restructured to subfolder)
-  'reference/motlp.md': 'reference/motlp/index.md'
+  # Managed OTLP Endpoint (mOTLP page moved to a sub-page under the new Managed inputs landing)
+  'reference/motlp.md': 'reference/motlp/managed-otlp-endpoint.md'
 
   # EDOT Collector troubleshooting pages (from reference to troubleshooting)
   'reference/edot-collector/troubleshooting/index.md': 'docs-content://troubleshoot/ingest/opentelemetry/edot-collector/index.md'

--- a/docs/reference/architecture/hosts_vms.md
+++ b/docs/reference/architecture/hosts_vms.md
@@ -31,7 +31,7 @@ The following sections outline the recommended architectures for different Elast
 :::::{applies-switch}
 
 ::::{applies-item} serverless:
-{{serverless-full}} provides a [Managed OTLP Endpoint](/reference/motlp/index.md) for ingestion of OpenTelemetry data.
+{{serverless-full}} provides a [Managed OTLP Endpoint](/reference/motlp/managed-otlp-endpoint.md) for ingestion of OpenTelemetry data.
 
 ![VM-Serverless](../images/host-serverless.png)
 
@@ -44,7 +44,7 @@ Users can send data direct from the Collectors or SDKs deployed on the edge envi
 You need an {{ech}} deployment version 9.0 or later.
 :::
 
-{{ech}} provides a [Managed OTLP Endpoint](/reference/motlp/index.md) for ingestion of OpenTelemetry data. Users can send data direct from the Collectors or SDKs deployed on the edge environment through OTLP without any additional requirements for managing an ingestion layer.
+{{ech}} provides a [Managed OTLP Endpoint](/reference/motlp/managed-otlp-endpoint.md) for ingestion of OpenTelemetry data. Users can send data direct from the Collectors or SDKs deployed on the edge environment through OTLP without any additional requirements for managing an ingestion layer.
 
 ![VM-ech](../images/host-ech.png)
 ::::

--- a/docs/reference/architecture/index.md
+++ b/docs/reference/architecture/index.md
@@ -60,7 +60,7 @@ When a Collector in gateway mode is deployed, it is considered part of the {{pro
 
 The need for an EDOT Collector in gateway mode as part of your Elastic backend depends on your deployment type:
 
-**{{serverless-full}} and {{ech}}**: Edge collectors can send OTLP data directly to the [Managed OTLP Endpoint](/reference/motlp/index.md) without requiring a self-managed Gateway Collector. The Managed OTLP Endpoint provides a fully managed ingestion layer as part of the Elastic backend. You can optionally deploy an EDOT Collector in gateway mode as part of your edge environment if you need additional processing before data reaches the Managed OTLP Endpoint.
+**{{serverless-full}} and {{ech}}**: Edge collectors can send OTLP data directly to the [Managed OTLP Endpoint](/reference/motlp/managed-otlp-endpoint.md) without requiring a self-managed Gateway Collector. The Managed OTLP Endpoint provides a fully managed ingestion layer as part of the Elastic backend. You can optionally deploy an EDOT Collector in gateway mode as part of your edge environment if you need additional processing before data reaches the Managed OTLP Endpoint.
 
 **Self-managed, ECE, and ECK deployments**: An EDOT Collector in gateway mode is **required as part of your {{product.observability}} backend**. This Gateway Collector exposes the OTLP endpoint that edge collectors send data to, and handles essential preprocessing, including:
 

--- a/docs/reference/architecture/k8s.md
+++ b/docs/reference/architecture/k8s.md
@@ -60,7 +60,7 @@ The following sections outline the recommended architectures for different Elast
 :::::{applies-switch}
 
 ::::{applies-item} serverless:
-{{serverless-full}} provides a [Managed OTLP Endpoint](/reference/motlp/index.md) for ingestion of OpenTelemetry data.
+{{serverless-full}} provides a [Managed OTLP Endpoint](/reference/motlp/managed-otlp-endpoint.md) for ingestion of OpenTelemetry data.
 
 ![K8s-Serverless](../images/k8s-serverless.png)
 
@@ -73,7 +73,7 @@ For a Kubernetes setup, the gateway Collector in your cluster sends OTLP data di
 You need an {{ech}} deployment version 9.0 or later.
 :::
 
-{{ech}} provides a [Managed OTLP Endpoint](/reference/motlp/index.md) for ingestion of OpenTelemetry data.
+{{ech}} provides a [Managed OTLP Endpoint](/reference/motlp/managed-otlp-endpoint.md) for ingestion of OpenTelemetry data.
 
 For a Kubernetes setup, the gateway Collector in your cluster sends OTLP data directly to the Managed OTLP Endpoint. There is no need for an EDOT gateway collector on the backend side.
 

--- a/docs/reference/compatibility/edot-vs-upstream.md
+++ b/docs/reference/compatibility/edot-vs-upstream.md
@@ -73,7 +73,7 @@ Due to current upstream limitations, some capabilities are temporarily available
 Upstream OTel SDKs are technically [Compatible] with Elastic and can send data through the same ingestion paths, but Elastic does not provide official support or troubleshooting assistance for them. Refer to the [SDK compatibility table](sdks.md) for version-level details.
 
 :::{important}
-EDOT SDKs are designed to export telemetry through the [EDOT Collector](elastic-agent://reference/edot-collector/index.md) or the [{{motlp}}](/reference/motlp/index.md). Using EDOT SDKs directly with {{product.apm-server}}'s OpenTelemetry intake is not supported — attribute mapping, enrichment, and processing pipelines are not guaranteed on that path.
+EDOT SDKs are designed to export telemetry through the [EDOT Collector](elastic-agent://reference/edot-collector/index.md) or the [{{motlp}}](/reference/motlp/managed-otlp-endpoint.md). Using EDOT SDKs directly with {{product.apm-server}}'s OpenTelemetry intake is not supported — attribute mapping, enrichment, and processing pipelines are not guaranteed on that path.
 :::
 
 ## Kubernetes Operator
@@ -88,7 +88,7 @@ On platforms that provide their own OpenTelemetry distributions, such as [Red Ha
 
 ## EDOT Cloud Forwarders
 
-The [EDOT Cloud Forwarders](/reference/edot-cloud-forwarder/index.md) are Elastic-specific components with no upstream equivalent. They package the EDOT Collector as a cloud function — AWS Lambda, Azure Function, or GCP Cloud Run — to collect telemetry from cloud provider services such as S3, CloudWatch, Blob Storage, Event Hub, GCS, and GCP Operations, and forward it to the [{{motlp}}](/reference/motlp/index.md).
+The [EDOT Cloud Forwarders](/reference/edot-cloud-forwarder/index.md) are Elastic-specific components with no upstream equivalent. They package the EDOT Collector as a cloud function — AWS Lambda, Azure Function, or GCP Cloud Run — to collect telemetry from cloud provider services such as S3, CloudWatch, Blob Storage, Event Hub, GCS, and GCP Operations, and forward it to the [{{motlp}}](/reference/motlp/managed-otlp-endpoint.md).
 
 Because there is no upstream counterpart, the EDOT-versus-upstream comparison does not apply to Cloud Forwarders. Refer to the [EDOT Cloud Forwarder documentation](/reference/edot-cloud-forwarder/index.md) for setup guides and supported cloud services.
 

--- a/docs/reference/compatibility/limitations.md
+++ b/docs/reference/compatibility/limitations.md
@@ -33,7 +33,7 @@ Refer to [EDOT data streams compared to classic APM](../compatibility/data-strea
 
 ## Centralized parsing and processing of data
 
-With OTel-native ingestion of data, for example through the EDOT Collector or the [Managed OTLP endpoint](/reference/motlp/index.md), [{{es}} Ingest Pipelines](docs-content://manage-data/ingest/transform-enrich/ingest-pipelines.md) are not supported.
+With OTel-native ingestion of data, for example through the EDOT Collector or the [Managed OTLP endpoint](/reference/motlp/managed-otlp-endpoint.md), [{{es}} Ingest Pipelines](docs-content://manage-data/ingest/transform-enrich/ingest-pipelines.md) are not supported.
 
 The OTel-native data format in {{es}} contains dotted fields. Ingest Pipeline processors can't access fields that have a dot in their name without having previously transformed the dotted field into an object using the [`Dot expander processor`](elasticsearch://reference/enrich-processor/dot-expand-processor.md).
 

--- a/docs/reference/edot-sdks/index.md
+++ b/docs/reference/edot-sdks/index.md
@@ -79,7 +79,7 @@ This table provides an overview of the features available in the {{edot}} (EDOT)
 
 ## Support for EDOT SDKs
 
-Elastic provides technical support for EDOT Language SDKs according to Elastic's [Support Policy](https://www.elastic.co/support_policy). EDOT SDKs are meant to be used in combination with the [EDOT Collector](elastic-agent://reference/edot-collector/index.md) or the [{{motlp}}](/reference/motlp/index.md) to ingest data into Elastic solutions from the EDOT SDKs. Other ingestion paths are not officially supported by Elastic.
+Elastic provides technical support for EDOT Language SDKs according to Elastic's [Support Policy](https://www.elastic.co/support_policy). EDOT SDKs are meant to be used in combination with the [EDOT Collector](elastic-agent://reference/edot-collector/index.md) or the [{{motlp}}](/reference/motlp/managed-otlp-endpoint.md) to ingest data into Elastic solutions from the EDOT SDKs. Other ingestion paths are not officially supported by Elastic.
 
 Using EDOT SDKs directly with {{product.apm-server}}'s OpenTelemetry intake endpoint is not supported.  
 While some data might ingest, Elastic doesn't guarantee:

--- a/docs/reference/motlp/index.md
+++ b/docs/reference/motlp/index.md
@@ -1,6 +1,6 @@
 ---
-navigation_title: Managed OTLP Endpoint
-description: Reference documentation for the Elastic Cloud Managed OTLP Endpoint.
+navigation_title: Managed inputs
+description: Managed inputs are fully managed ingestion endpoints for sending telemetry to Elastic Cloud.
 applies_to:
   serverless:
     observability: ga
@@ -10,170 +10,15 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
-  - id: edot-collector
 ---
 
-# Elastic Cloud Managed OTLP Endpoint (mOTLP)
+# Managed inputs [managed-inputs]
 
-The {{motlp}} allows you to send OpenTelemetry data directly to {{ecloud}} using the OTLP protocol. 
+Managed inputs are fully managed ingestion endpoints for sending telemetry to {{ecloud}}. Each input exposes a protocol-specific endpoint that buffers data, applies back-pressure, and routes it into {{es}}, so you don't need to run your own ingestion infrastructure.
 
-The endpoint provides a resilient ingestion layer that works seamlessly with serverless autoscaling and offloads ingestion processing from {{ech}} clusters.
+Managed inputs are the recommended ingestion path for {{ecloud}}. The following managed inputs are available:
 
-:::{important}
-The {{motlp}} endpoint is not available for Elastic [self-managed](docs-content://deploy-manage/deploy/self-managed.md), [ECE](docs-content://deploy-manage/deploy/cloud-enterprise.md), or [ECK](docs-content://deploy-manage/deploy/cloud-on-k8s.md) clusters. To send OTLP data to any of these cluster types, deploy and expose an OTLP-compatible endpoint using the [EDOT Collector as a gateway](elastic-agent://reference/edot-collector/modes.md#edot-collector-as-gateway).
-:::
-
-## Prerequisites
-
-To use the {{ecloud}} {{motlp}} you need the following:
-
-- An {{serverless-full}} project or an {{ech}} (ECH) deployment.
-- An OTLP-compliant shipper capable of forwarding logs, metrics, or traces in OTLP format. This can include:
-  - [OpenTelemetry Collector](elastic-agent://reference/edot-collector/index.md) (EDOT, Contrib, or other distributions)
-  - [OpenTelemetry SDKs](/reference/edot-sdks/index.md) (EDOT, upstream, or other distributions)
-  - [EDOT Cloud Forwarder](/reference/edot-cloud-forwarder/index.md)
-  - Any other forwarder that supports the OTLP protocol.
-
-You don't need APM Server when ingesting data through the Managed OTLP Endpoint. The APM integration (`.apm` endpoint) is a legacy ingest path that translates OTLP telemetry to ECS, whereas {{motlp}} natively ingests OTLP data.
-
-## Send data to the Managed OTLP Endpoint
-
-To send data to Elastic through the {{motlp}}, follow the [Send data to the Elastic Cloud Managed OTLP Endpoint](docs-content://solutions/observability/get-started/quickstart-elastic-cloud-otel-endpoint.md) quickstart.
-
-### Find your {{motlp}}
-
-:::{include} ../_snippets/find-motlp-endpoint.md
-:::
-
-### Configure SDKs to send data directly
-
-To configure OpenTelemetry SDKs to send data directly to the {{motlp}}, set the `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_HEADERS` environment variables.
-
-For example:
-
-```bash
-export OTEL_EXPORTER_OTLP_ENDPOINT="https://<motlp-endpoint>"
-export OTEL_EXPORTER_OTLP_HEADERS="Authorization=ApiKey <key>"
-```
-
-### Routing telemetry to dedicated datasets or namespace
-
-You can route signals to dedicated datasets by setting the `data_stream.dataset` attribute on the record. This attribute is used to route the signal to the corresponding dataset.
-
-For example, if you want to route the {{edot-cf}} logs to custom datasets, you can add the following attributes to the log records:
-
-```yaml
-processors:
-  transform:
-    log_statements:
-      - set(log.attributes["data_stream.dataset"], "aws.cloudtrail") where log.attributes["aws.cloudtrail.event_id"] != nil
-```
-
-You can also set the `OTEL_RESOURCE_ATTRIBUTES` environment variable to set the `data_stream.dataset` attribute for all logs. For example:
-
-```bash
-export OTEL_RESOURCE_ATTRIBUTES="data_stream.dataset=app.orders"
-```
-
-The  `data_stream.namespace` attributes is also honored for all signals: logs, metrics, and traces.
-
-:::{important}
-Any `data_stream.dataset` or `data_stream.namespace` resource attribute present in an OTLP payload overrides mOTLP's default routing for that signal. This applies whether the attribute is set intentionally or by a collector, SDK, or integration.
-
-If data is landing in an unexpected data stream, inspect a sample document from that data stream for the field `resource.attributes.data_stream.dataset`. If the field is present and matches the unexpected data stream name, the attribute was set in the payload, not by the pipeline.
-
-To restore default routing, remove the `data_stream.dataset` and `data_stream.namespace` resource attributes from your OTLP payload configuration. Once removed, mOTLP falls back to routing based on `service.name`.
-:::
-
-## Authentication
-
-The {{motlp}} authenticates requests using {{product.apm}} application privileges. To send data to the endpoint, your API key must include the `event:write` privilege for the `apm` application:
-
-```json
-{
-  "otlp_writer": {
-    "applications": [
-      {
-        "application": "apm",
-        "resources": ["*"],
-        "privileges": ["event:write"]
-      }
-    ]
-  }
-}
-```
-
-For step-by-step instructions on generating an API key, refer to the [Send data to the {{motlp}}](docs-content://solutions/observability/get-started/quickstart-elastic-cloud-otel-endpoint.md) quickstart.
-
-:::{note}
-Index-level privilege scoping is not yet supported for the {{motlp}}. API keys restricted to specific index-level privileges return a `PermissionDenied` error.
-:::
-
-## OTLP client configuration
-
-When using OpenTelemetry collectors to send data to the {{motlp}}, configure the OTLP exporter to leverage an in-memory queue and optimized batching defaults. This improves throughput, minimizes data loss, and maintains low end-to-end latency.
-
-```yaml
-exporters:
-  otlp/elastic:
-    endpoint: "${MOTLP_ENDPOINT}"
-    headers:
-      Authorization: "ApiKey <key>"
-    sending_queue:
-      enabled: true
-      sizer: bytes
-      queue_size: 50_000_000
-      block_on_overflow: true
-      batch:
-        flush_timeout: 1s
-        min_size: 1_000_000
-        max_size: 4_000_000
-```
-
-The key settings are:
-
-* **`sending_queue`**: Enables an in-memory queue with byte-based sizing (`sizer: bytes`) and a 50 MB capacity. `block_on_overflow: true` applies backpressure instead of dropping data when the queue is full.
-* **`batch`**: Controls how queued data is batched before export. A `flush_timeout` of 1 second ensures low latency, while `min_size` (1 MB) and `max_size` (4 MB) keep payloads within the {{motlp}} limits. Refer to the [Payload too large](troubleshooting.md#error-payload-too-large) troubleshooting section for details on payload size limits.
-
-## Reference architecture
-
-This diagram shows data ingest using {{edot}} and the {{motlp}}:
-
-:::{image} ../images/motlp-reference-architecture.png
-:alt: mOTLP Reference architecture
-:width: 100%
-:::
-
-Telemetry is stored in Elastic in OTLP format, preserving resource attributes and original semantic conventions. If no specific dataset or namespace is provided, telemetry would be routed to the generic data streams: `traces-generic.otel-default`, `metrics-generic.otel-default`, and `logs-generic.otel-default`.
-
-For a detailed comparison of how OTel data streams differ from classic Elastic APM data streams, refer to [OTel data streams compared to classic APM](../compatibility/data-streams.md).
-
-## Failure store
-
-```{applies_to}
-stack: ga 9.1+
-```
-
-The {{motlp}} endpoint is built for high availability, but some failures can still prevent telemetry events from being written to your {{es}} cluster (for example, ingest pipeline errors or mapping conflicts).
-
-To protect data in these cases, {{motlp}} uses the [Failure store](docs-content://manage-data/data-store/data-streams/failure-store.md). For {{motlp}} data streams, the failure store is always enabled.
-
-When indexing fails, the original documents are written to a dedicated failure index instead of being dropped. This keeps ingestion resilient and gives you a recovery path for partial or failed sends.
-
-You can inspect and triage these documents from **Data Set Quality**. Refer to [Data set quality](docs-content://solutions/observability/data-set-quality-monitoring.md).
-
-## Limitations
-
-The following limitations apply when using the {{motlp}}:
-
-* Universal Profiling is not available.
-* Only supports histograms with delta temporality. Cumulative histograms are dropped.
-* Latency distributions based on histogram values have limited precision due to the fixed boundaries of explicit bucket histograms.
-* Tail-based sampling (TBS) is not available. The {{motlp}} does not provide centralized hosted sampling. If you need tail-based sampling, configure it on the edge using the [Tail Sampling Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor) in your EDOT or OpenTelemetry Collector before sending data to the endpoint.
-* In {{ech}} deployments:
-  * [IP filters](docs-content://deploy-manage/security/ip-filtering-cloud.md) do not apply to the managed endpoint.
-  * The endpoint is not available over a [private connection](docs-content://deploy-manage/security/private-connectivity.md). When private connectivity is configured, the public managed endpoint is still available.
-
-## Billing
-
-For more information on billing, refer to [Elastic Cloud pricing](https://www.elastic.co/pricing/serverless-observability).
+| Input | Protocol | Use it to |
+| --- | --- | --- |
+| [Managed OTLP Endpoint](managed-otlp-endpoint.md) | OpenTelemetry Protocol (OTLP) | Ingest OpenTelemetry logs, metrics, and traces from EDOT or upstream collectors and SDKs. |
+| [Prometheus Remote Write](prometheus-remote-write.md) | Prometheus Remote Write v1 (PRW) | Ingest Prometheus metrics into {{es}} time series data streams. |

--- a/docs/reference/motlp/managed-otlp-endpoint.md
+++ b/docs/reference/motlp/managed-otlp-endpoint.md
@@ -1,0 +1,179 @@
+---
+navigation_title: Managed OTLP Endpoint
+description: Reference documentation for the Elastic Cloud Managed OTLP Endpoint.
+applies_to:
+  serverless:
+    observability: ga
+    security: ga
+  deployment:
+    ech: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: edot-collector
+---
+
+# Elastic Cloud Managed OTLP Endpoint (mOTLP)
+
+The {{motlp}} allows you to send OpenTelemetry data directly to {{ecloud}} using the OTLP protocol. 
+
+The endpoint provides a resilient ingestion layer that works seamlessly with serverless autoscaling and offloads ingestion processing from {{ech}} clusters.
+
+:::{important}
+The {{motlp}} endpoint is not available for Elastic [self-managed](docs-content://deploy-manage/deploy/self-managed.md), [ECE](docs-content://deploy-manage/deploy/cloud-enterprise.md), or [ECK](docs-content://deploy-manage/deploy/cloud-on-k8s.md) clusters. To send OTLP data to any of these cluster types, deploy and expose an OTLP-compatible endpoint using the [EDOT Collector as a gateway](elastic-agent://reference/edot-collector/modes.md#edot-collector-as-gateway).
+:::
+
+## Prerequisites
+
+To use the {{ecloud}} {{motlp}} you need the following:
+
+- An {{serverless-full}} project or an {{ech}} (ECH) deployment.
+- An OTLP-compliant shipper capable of forwarding logs, metrics, or traces in OTLP format. This can include:
+  - [OpenTelemetry Collector](elastic-agent://reference/edot-collector/index.md) (EDOT, Contrib, or other distributions)
+  - [OpenTelemetry SDKs](/reference/edot-sdks/index.md) (EDOT, upstream, or other distributions)
+  - [EDOT Cloud Forwarder](/reference/edot-cloud-forwarder/index.md)
+  - Any other forwarder that supports the OTLP protocol.
+
+You don't need APM Server when ingesting data through the Managed OTLP Endpoint. The APM integration (`.apm` endpoint) is a legacy ingest path that translates OTLP telemetry to ECS, whereas {{motlp}} natively ingests OTLP data.
+
+## Send data to the Managed OTLP Endpoint
+
+To send data to Elastic through the {{motlp}}, follow the [Send data to the Elastic Cloud Managed OTLP Endpoint](docs-content://solutions/observability/get-started/quickstart-elastic-cloud-otel-endpoint.md) quickstart.
+
+### Find your {{motlp}}
+
+:::{include} ../_snippets/find-motlp-endpoint.md
+:::
+
+### Configure SDKs to send data directly
+
+To configure OpenTelemetry SDKs to send data directly to the {{motlp}}, set the `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_HEADERS` environment variables.
+
+For example:
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT="https://<motlp-endpoint>"
+export OTEL_EXPORTER_OTLP_HEADERS="Authorization=ApiKey <key>"
+```
+
+### Routing telemetry to dedicated datasets or namespace
+
+You can route signals to dedicated datasets by setting the `data_stream.dataset` attribute on the record. This attribute is used to route the signal to the corresponding dataset.
+
+For example, if you want to route the {{edot-cf}} logs to custom datasets, you can add the following attributes to the log records:
+
+```yaml
+processors:
+  transform:
+    log_statements:
+      - set(log.attributes["data_stream.dataset"], "aws.cloudtrail") where log.attributes["aws.cloudtrail.event_id"] != nil
+```
+
+You can also set the `OTEL_RESOURCE_ATTRIBUTES` environment variable to set the `data_stream.dataset` attribute for all logs. For example:
+
+```bash
+export OTEL_RESOURCE_ATTRIBUTES="data_stream.dataset=app.orders"
+```
+
+The  `data_stream.namespace` attributes is also honored for all signals: logs, metrics, and traces.
+
+:::{important}
+Any `data_stream.dataset` or `data_stream.namespace` resource attribute present in an OTLP payload overrides mOTLP's default routing for that signal. This applies whether the attribute is set intentionally or by a collector, SDK, or integration.
+
+If data is landing in an unexpected data stream, inspect a sample document from that data stream for the field `resource.attributes.data_stream.dataset`. If the field is present and matches the unexpected data stream name, the attribute was set in the payload, not by the pipeline.
+
+To restore default routing, remove the `data_stream.dataset` and `data_stream.namespace` resource attributes from your OTLP payload configuration. Once removed, mOTLP falls back to routing based on `service.name`.
+:::
+
+## Authentication
+
+The {{motlp}} authenticates requests using {{product.apm}} application privileges. To send data to the endpoint, your API key must include the `event:write` privilege for the `apm` application:
+
+```json
+{
+  "otlp_writer": {
+    "applications": [
+      {
+        "application": "apm",
+        "resources": ["*"],
+        "privileges": ["event:write"]
+      }
+    ]
+  }
+}
+```
+
+For step-by-step instructions on generating an API key, refer to the [Send data to the {{motlp}}](docs-content://solutions/observability/get-started/quickstart-elastic-cloud-otel-endpoint.md) quickstart.
+
+:::{note}
+Index-level privilege scoping is not yet supported for the {{motlp}}. API keys restricted to specific index-level privileges return a `PermissionDenied` error.
+:::
+
+## OTLP client configuration
+
+When using OpenTelemetry collectors to send data to the {{motlp}}, configure the OTLP exporter to leverage an in-memory queue and optimized batching defaults. This improves throughput, minimizes data loss, and maintains low end-to-end latency.
+
+```yaml
+exporters:
+  otlp/elastic:
+    endpoint: "${MOTLP_ENDPOINT}"
+    headers:
+      Authorization: "ApiKey <key>"
+    sending_queue:
+      enabled: true
+      sizer: bytes
+      queue_size: 50_000_000
+      block_on_overflow: true
+      batch:
+        flush_timeout: 1s
+        min_size: 1_000_000
+        max_size: 4_000_000
+```
+
+The key settings are:
+
+* **`sending_queue`**: Enables an in-memory queue with byte-based sizing (`sizer: bytes`) and a 50 MB capacity. `block_on_overflow: true` applies backpressure instead of dropping data when the queue is full.
+* **`batch`**: Controls how queued data is batched before export. A `flush_timeout` of 1 second ensures low latency, while `min_size` (1 MB) and `max_size` (4 MB) keep payloads within the {{motlp}} limits. Refer to the [Payload too large](troubleshooting.md#error-payload-too-large) troubleshooting section for details on payload size limits.
+
+## Reference architecture
+
+This diagram shows data ingest using {{edot}} and the {{motlp}}:
+
+:::{image} ../images/motlp-reference-architecture.png
+:alt: mOTLP Reference architecture
+:width: 100%
+:::
+
+Telemetry is stored in Elastic in OTLP format, preserving resource attributes and original semantic conventions. If no specific dataset or namespace is provided, telemetry would be routed to the generic data streams: `traces-generic.otel-default`, `metrics-generic.otel-default`, and `logs-generic.otel-default`.
+
+For a detailed comparison of how OTel data streams differ from classic Elastic APM data streams, refer to [OTel data streams compared to classic APM](../compatibility/data-streams.md).
+
+## Failure store
+
+```{applies_to}
+stack: ga 9.1+
+```
+
+The {{motlp}} endpoint is built for high availability, but some failures can still prevent telemetry events from being written to your {{es}} cluster (for example, ingest pipeline errors or mapping conflicts).
+
+To protect data in these cases, {{motlp}} uses the [Failure store](docs-content://manage-data/data-store/data-streams/failure-store.md). For {{motlp}} data streams, the failure store is always enabled.
+
+When indexing fails, the original documents are written to a dedicated failure index instead of being dropped. This keeps ingestion resilient and gives you a recovery path for partial or failed sends.
+
+You can inspect and triage these documents from **Data Set Quality**. Refer to [Data set quality](docs-content://solutions/observability/data-set-quality-monitoring.md).
+
+## Limitations
+
+The following limitations apply when using the {{motlp}}:
+
+* Universal Profiling is not available.
+* Only supports histograms with delta temporality. Cumulative histograms are dropped.
+* Latency distributions based on histogram values have limited precision due to the fixed boundaries of explicit bucket histograms.
+* Tail-based sampling (TBS) is not available. The {{motlp}} does not provide centralized hosted sampling. If you need tail-based sampling, configure it on the edge using the [Tail Sampling Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor) in your EDOT or OpenTelemetry Collector before sending data to the endpoint.
+* In {{ech}} deployments:
+  * [IP filters](docs-content://deploy-manage/security/ip-filtering-cloud.md) do not apply to the managed endpoint.
+  * The endpoint is not available over a [private connection](docs-content://deploy-manage/security/private-connectivity.md). When private connectivity is configured, the public managed endpoint is still available.
+
+## Billing
+
+For more information on billing, refer to [Elastic Cloud pricing](https://www.elastic.co/pricing/serverless-observability).

--- a/docs/reference/motlp/prometheus-remote-write.md
+++ b/docs/reference/motlp/prometheus-remote-write.md
@@ -28,7 +28,7 @@ Sending PRW metrics directly to the [{{es}} Prometheus remote write endpoint](do
 ## Prerequisites
 
 - An {{serverless-full}} Observability project.
-- A Managed Inputs API key with the `event:write` privilege for the `apm` application. Refer to [Authentication](index.md#authentication) for the required key format and generation steps.
+- A Managed Inputs API key with the `event:write` privilege for the `apm` application. Refer to [Authentication](managed-otlp-endpoint.md#authentication) for the required key format and generation steps.
 
 ## Send Prometheus metrics through Managed Inputs
 

--- a/docs/reference/motlp/toc.yml
+++ b/docs/reference/motlp/toc.yml
@@ -1,5 +1,7 @@
 toc:
   - file: index.md
+  - file: managed-otlp-endpoint.md
+    children:
+      - file: rate-limiting.md
+      - file: troubleshooting.md
   - file: prometheus-remote-write.md
-  - file: rate-limiting.md
-  - file: troubleshooting.md


### PR DESCRIPTION
## Summary

Restructures the Managed OTLP Endpoint and Prometheus Remote Write docs under a new **Managed inputs** landing page, instead of nesting Prometheus Remote Write beneath the Managed OTLP Endpoint page. This removes the confusing hierarchy where a distinct managed input appeared as a sub-page of another.

## Changes

- Add a `Managed inputs` landing page (`motlp/index.md`) with a short overview and a table of the available managed inputs.
- Move the Managed OTLP Endpoint content to its own page (`motlp/managed-otlp-endpoint.md`) and update `toc.yml` so both inputs sit at the same level.
- Add a redirect for the old Managed OTLP Endpoint URL and repoint internal cross-references.

This is the first of a few stacked PRs addressing https://github.com/elastic/docs-content/issues/7155.

Navigation re-nesting in `docs-builder`: https://github.com/elastic/docs-builder/pull/3598