### PR TITLE
Fix Managed inputs landing page redirect

### DIFF
--- a/docs/redirects.yml
+++ b/docs/redirects.yml
@@ -4,8 +4,8 @@ redirects:
   'reference/edot-cloud-forwarder/azure/index.md': 'edot-cloud-forwarder-azure://reference/edot-cf-azure/index.md'
   'reference/edot-cloud-forwarder/gcp.md': 'reference/edot-cloud-forwarder/gcp/index.md'
 
-  # Managed OTLP Endpoint (mOTLP page moved to a sub-page under the new Managed inputs landing)
-  'reference/motlp.md': 'reference/motlp/managed-otlp-endpoint.md'
+  # The old motlp.md URL (/reference/motlp) is now served by the Managed inputs landing page (motlp/index.md)
+  'reference/motlp.md': 'reference/motlp/index.md'
 
   # EDOT Collector troubleshooting pages (from reference to troubleshooting)
   'reference/edot-collector/troubleshooting/index.md': 'docs-content://troubleshoot/ingest/opentelemetry/edot-collector/index.md'


### PR DESCRIPTION
## Problem

After #630 merged, the **Managed inputs** landing page (`/reference/motlp`) can't be opened — it redirects to the Managed OTLP Endpoint page.

## Cause

The old `reference/motlp.md` and the new landing page `reference/motlp/index.md` resolve to the **same URL** (`/reference/motlp`). #630 changed the redirect for `reference/motlp.md` to target `managed-otlp-endpoint.md`, which turned a harmless same-URL self-mapping into a real redirect that hijacks the landing page.

## Fix

Point the redirect back at the landing page (`reference/motlp/index.md`), matching the pre-#630 behavior. `/reference/motlp` now serves the Managed inputs landing again; old bookmarks reach the Managed OTLP Endpoint via the landing page's link.

Related to elastic/docs-content#7155

Made with [Cursor](https://cursor.com)