### PR TITLE
docs: retire EDOT brand across all reference docs (9.5)

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -1,6 +1,6 @@
-# Contributing to the EDOT docs
+# Contributing to the Elastic OpenTelemetry docs
 
-This repository contains the EDOT documentation. We welcome pull requests.
+This repository contains the Elastic OpenTelemetry documentation. We welcome pull requests.
 
 ## Format and syntax
 
@@ -20,14 +20,14 @@ docs
     ├── _snippets          # Reusable snippets
     ├── architecture       # Architecture section
     ├── compatibility      # Compatibility and support
-    ├── edot-collector     # EDOT Collector
-    ├── edot-sdks          # EDOT SDKs
+    ├── edot-collector     # Elastic Agent (OTel mode)
+    ├── edot-sdks          # Elastic OTel SDKs
     ├── images             # Images
     ├── quickstart         # Quickstarts
     └── use-cases          # Use cases
 ```
 
-This structure might evolve as we refine the EDOT documentation according to the new V3 information architecture.
+This structure might evolve as we refine the Elastic OpenTelemetry documentation according to the new V3 information architecture.
 
 ## Style guide
 
@@ -43,19 +43,19 @@ Use the following terms consistently and respect capitalization.
 
 | Term | Description | Alias | Example |
 |---|---|---|---|
-| **Elastic Distributions of OpenTelemetry** | Use to describe all distributions built by Elastic collectively | EDOTs | Use one of the Elastic Distributions of OpenTelemetry (EDOTs) in your application. EDOTs include... |
-| **Elastic Distributions of OpenTelemetry language SDKs** | Use to describe the collection of all the Elastic distributions that extend language SDKs (i.e. the APM-related distros) | EDOT language SDKs | With the Elastic Distributions of OpenTelemetry (EDOT) language SDKs you have access to all the features of the OpenTelemetry SDK that it customizes, plus... |
-| **Elastic Distribution of OpenTelemetry {language}** | Use to refer to a specific language distribution | EDOT {language} | The Elastic Distribution of OpenTelemetry (EDOT) Java is a Java package that provides an easy way to instrument your application with OpenTelemetry and configuration defaults for best usage. EDOT Java is a wrapper around... |
-| **Elastic Distribution of OpenTelemetry Collector** | Use to describe the customized version of the OpenTelemetry Collector that is built and maintained by Elastic | EDOT Collector | This guide shows you how to use the Elastic Distribution of OpenTelemetry (EDOT) Collector. The EDOT Collector sends logs and host metrics to Elastic Cloud. |
-| **Upstream** | Use to describe the upstream OpenTelemetry solutions. Do not use "vanilla" or other terms. |  | The upstream OpenTelemetry Collector is maintained by the OpenTelemetry community. |
-| **Collector** | Use it to refer to any Collector instance, either upstream or EDOT. Always capitalize Collector when referring to the technical solution. Use lowercase when referring to multiple collectors. |  | Deploy a Collector to receive and process telemetry data. Multiple collectors can be used for scaling. |
+| **Elastic OpenTelemetry** | Use to describe Elastic's OpenTelemetry offerings collectively | Elastic OTel | Use Elastic OpenTelemetry to instrument your applications and infrastructure and send telemetry to Elastic Observability. |
+| **Elastic OTel SDKs** | Use to describe the collection of all Elastic OTel language SDKs | — | With the Elastic OTel SDKs you have access to all the features of the OpenTelemetry SDK, plus Elastic-specific defaults and enhancements. |
+| **Elastic OTel {language}** | Use to refer to a specific language SDK | — | The Elastic OTel Java SDK is a Java package that provides an easy way to instrument your application with OpenTelemetry and configuration defaults for best usage. |
+| **Elastic Agent** | Use to describe Elastic Agent running in OpenTelemetry mode (available from 9.5; formerly called the EDOT Collector). | — | Deploy Elastic Agent in OTel mode to collect and forward telemetry data to Elastic Observability. |
+| **Elastic Cloud Forwarder** | Use to describe the cloud-native forwarder for AWS, GCP, and Azure. | — | Use the Elastic Cloud Forwarder to send telemetry from your cloud environment to Elastic Observability. |
+| **Upstream** | Use to describe the upstream OpenTelemetry solutions. Do not use "vanilla" or other terms. | — | The upstream OpenTelemetry Collector is maintained by the OpenTelemetry community. |
+| **Collector** | Use to refer to any Collector instance, either upstream or Elastic. Always capitalize Collector when referring to the technical solution. Use lowercase when referring to multiple collectors. | — | Deploy a Collector to receive and process telemetry data. Multiple collectors can be used for scaling. |
 
-Keep these rules in mind when using EDOT terms:
+Keep these rules in mind when writing about Elastic OpenTelemetry:
 
 * Always use the full product name the first time you refer to the product on each page.
-* Always establish the acronym for the product name (for example, EDOT) the first time it is mentioned in the body text.
-  * Note: Do *not* establish the acronym for the first time in the page title or in a heading. If a heading comes *after* the first time the acronym is established in the body text, then it's ok to use the acronym instead of the full product name in the heading.
-* Avoid overusing the full product name. Use the shorter, already-established alias.
+* Avoid referring to "EDOT" as a product name in new content. It is a legacy term used before 9.5. Historical references in pre-9.5 release notes are acceptable.
+* Avoid overusing the full product name. Use the shorter alias after the first mention.
 
 ## Frontmatter
 

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -21,7 +21,7 @@ docs
     ├── architecture       # Architecture section
     ├── compatibility      # Compatibility and support
     ├── edot-collector     # Elastic Agent (OTel mode)
-    ├── edot-sdks          # Elastic OTel SDKs
+    ├── edot-sdks          # EDOT SDKs
     ├── images             # Images
     ├── quickstart         # Quickstarts
     └── use-cases          # Use cases

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -43,9 +43,9 @@ Use the following terms consistently and respect capitalization.
 
 | Term | Description | Alias | Example |
 |---|---|---|---|
-| **Elastic OpenTelemetry** | Use to describe Elastic's OpenTelemetry offerings collectively | Elastic OTel | Use Elastic OpenTelemetry to instrument your applications and infrastructure and send telemetry to Elastic Observability. |
-| **Elastic OTel SDKs** | Use to describe the collection of all Elastic OTel language SDKs | — | With the Elastic OTel SDKs you have access to all the features of the OpenTelemetry SDK, plus Elastic-specific defaults and enhancements. |
-| **Elastic OTel {language}** | Use to refer to a specific language SDK | — | The Elastic OTel Java SDK is a Java package that provides an easy way to instrument your application with OpenTelemetry and configuration defaults for best usage. |
+| **Elastic OpenTelemetry** | Use to describe Elastic's OpenTelemetry brand collectively | Elastic OTel | Use Elastic OpenTelemetry to instrument your applications and infrastructure and send telemetry to Elastic Observability. |
+| **EDOT SDKs** | Use to describe the collection of Elastic language SDKs | EDOT {language} | With the EDOT SDKs you have access to all the features of the OpenTelemetry SDK that it customizes, plus... |
+| **EDOT {language}** | Use to refer to a specific language SDK | EDOT {language} | The EDOT Java SDK is a Java package that provides an easy way to instrument your application with OpenTelemetry and configuration defaults for best usage. |
 | **Elastic Agent** | Use to describe Elastic Agent running in OpenTelemetry mode (available from 9.5; formerly called the EDOT Collector). | — | Deploy Elastic Agent in OTel mode to collect and forward telemetry data to Elastic Observability. |
 | **Elastic Cloud Forwarder** | Use to describe the cloud-native forwarder for AWS, GCP, and Azure. | — | Use the Elastic Cloud Forwarder to send telemetry from your cloud environment to Elastic Observability. |
 | **Upstream** | Use to describe the upstream OpenTelemetry solutions. Do not use "vanilla" or other terms. | — | The upstream OpenTelemetry Collector is maintained by the OpenTelemetry community. |
@@ -54,7 +54,8 @@ Use the following terms consistently and respect capitalization.
 Keep these rules in mind when writing about Elastic OpenTelemetry:
 
 * Always use the full product name the first time you refer to the product on each page.
-* Avoid referring to "EDOT" as a product name in new content. It is a legacy term used before 9.5. Historical references in pre-9.5 release notes are acceptable.
+* EDOT SDK names (EDOT Java, EDOT Python, EDOT .NET, etc.) remain unchanged. Continue using the EDOT brand for SDK references.
+* For the Collector and generic brand, use the new Elastic names (Elastic Agent, Elastic OpenTelemetry).
 * Avoid overusing the full product name. Use the shorter alias after the first mention.
 
 ## Frontmatter

--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -1,4 +1,4 @@
-project: 'EDOT documentation'
+project: 'Elastic OpenTelemetry documentation'
 cross_links:
   - apm-agent-android
   - apm-agent-dotnet
@@ -36,9 +36,10 @@ toc:
 
 subs:
   motlp: Elastic Cloud Managed OTLP Endpoint
-  edot: Elastic Distribution of OpenTelemetry
+  edot: Elastic OpenTelemetry
+  agent: "Elastic Agent"
   ecloud:   "Elastic Cloud"
-  edot-cf:   "EDOT Cloud Forwarder"
+  edot-cf:   "Elastic Cloud Forwarder"
   ech:   "Elastic Cloud Hosted"
   serverless-full:   "Elastic Cloud Serverless"
   stack:   "Elastic Stack"

--- a/docs/reference/architecture/hosts_vms.md
+++ b/docs/reference/architecture/hosts_vms.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Hosts / VMs environments
-description: Recommended EDOT architecture for host or virtual machine environments.
+description: Recommended {{edot}} architecture for host or virtual machine environments.
 applies_to:
   stack:
   serverless:
@@ -50,14 +50,14 @@ You need an {{ech}} deployment version 9.0 or later.
 ::::
 
 ::::{applies-item} { eck:, ece:, self: }
-In a self-managed Elastic deployment, we recommend running an EDOT Collector in gateway mode as a unified ingestion layer for OTLP telemetry from OpenTelemetry collectors or SDKs running at the edge. This gateway can receive all signals (logs, metrics and traces), apply processing as needed, and cover the same use cases that previously required components like {{product.apm-server}} or {{product.logstash}}.
+In a self-managed Elastic deployment, we recommend running an {{agent}} in gateway mode as a unified ingestion layer for OTLP telemetry from OpenTelemetry collectors or SDKs running at the edge. This gateway can receive all signals (logs, metrics and traces), apply processing as needed, and cover the same use cases that previously required components like {{product.apm-server}} or {{product.logstash}}.
 
 Depending on your scalability and durability needs, this can be a single collector that scales horizontally, or a chain of collectors where each tier handles a specific concern. For high availability and stronger durability guarantees, you can insert Kafka between tiers so that ingestion is buffered and resilient to downstream outages.
 
 ![VM-self-managed](../images/host-self-managed.png)
 
 :::{note}
-Compared to [Elastic's classic ingestion paths](docs-content://solutions/observability/apm/use-opentelemetry-with-apm.md) for OTel data, with the EDOT Collector in gateway mode there is no need for {{product.apm-server}} anymore. 
+Compared to [Elastic's classic ingestion paths](docs-content://solutions/observability/apm/use-opentelemetry-with-apm.md) for OTel data, with the {{agent}} in gateway mode there is no need for {{product.apm-server}} anymore. 
 
 Refer to [data streams compared to classic {{product.apm}}](../compatibility/data-streams.md) for a detailed comparison of data streams, mappings, and storage models.
 :::

--- a/docs/reference/architecture/index.md
+++ b/docs/reference/architecture/index.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Reference Architecture
-description: Recommended architectures for EDOT with different Elastic deployment options.
+description: Recommended architectures for {{edot}} with different Elastic deployment options.
 applies_to:
   stack:
   serverless:
@@ -11,9 +11,9 @@ products:
   - id: edot-collector
 ---
 
-# EDOT reference architecture
+# {{edot}} reference architecture
 
-The following sections outline the recommended architectures for Elastic Distributions of OpenTelemetry (EDOT) with different Elastic deployment options.
+The following sections outline the recommended architectures for {{edot}} with different Elastic deployment options.
 
 - [Hosts and VMs](hosts_vms.md)
 - [Kubernetes](k8s.md)
@@ -32,12 +32,12 @@ You can use any OpenTelemetry Collector distribution at the edge, including:
 
 - The contrib OpenTelemetry Collector.
 - Custom-built Collector distributions.
-- The {{edot}} Collector.
+- The {{agent}}.
 - Any shipper capable of sending valid OTLP data.
 
-The only requirement is that collectors deployed on edge environments send data using valid OpenTelemetry Protocol (OTLP) to {{ecloud}} (using managed OTLP endpoint) or to the OTLP receiver of a gateway EDOT collector for self-managed deployments.
+The only requirement is that collectors deployed on edge environments send data using valid OpenTelemetry Protocol (OTLP) to {{ecloud}} (using managed OTLP endpoint) or to the OTLP receiver of a gateway {{agent}} for self-managed deployments.
 
-While any OTLP-compatible collector works at the edge, using EDOT provides a more streamlined experience with:
+While any OTLP-compatible collector works at the edge, using {{edot}} provides a more streamlined experience with:
 
 - Preconfigured components optimized for {{product.observability}}.
 - Curated receivers and processors for common use cases.
@@ -50,7 +50,7 @@ The {{product.observability}} backend is the ingestion and storage layer where y
 - **{{es}}**: Stores and indexes your telemetry data.
 - **{{kib}}**: Provides visualization and analysis interfaces.
 - **Managed OTLP Endpoint** (for {{serverless-full}} and {{ech}}): A managed ingestion service that receives OTLP data.
-- **Gateway Collector** (for self-managed, ECE, and ECK): An EDOT Collector running in gateway mode that serves as the ingestion layer.
+- **Gateway Collector** (for self-managed, ECE, and ECK): An {{agent}} running in gateway mode that serves as the ingestion layer.
 
 :::{note}
 When a Collector in gateway mode is deployed, it is considered part of the {{product.observability}} backend, not part of the edge deployment. The Collector in gateway mode sits between your edge collectors and {{es}}, acting as a centralized ingestion and preprocessing layer.
@@ -58,11 +58,11 @@ When a Collector in gateway mode is deployed, it is considered part of the {{pro
 
 ### When gateway mode is required
 
-The need for an EDOT Collector in gateway mode as part of your Elastic backend depends on your deployment type:
+The need for an {{agent}} in gateway mode as part of your Elastic backend depends on your deployment type:
 
-**{{serverless-full}} and {{ech}}**: Edge collectors can send OTLP data directly to the [Managed OTLP Endpoint](/reference/managed-inputs/managed-otlp-endpoint.md) without requiring a self-managed Gateway Collector. The Managed OTLP Endpoint provides a fully managed ingestion layer as part of the Elastic backend. You can optionally deploy an EDOT Collector in gateway mode as part of your edge environment if you need additional processing before data reaches the Managed OTLP Endpoint.
+**{{serverless-full}} and {{ech}}**: Edge collectors can send OTLP data directly to the [Managed OTLP Endpoint](/reference/managed-inputs/managed-otlp-endpoint.md) without requiring a self-managed Gateway Collector. The Managed OTLP Endpoint provides a fully managed ingestion layer as part of the Elastic backend. You can optionally deploy an {{agent}} in gateway mode as part of your edge environment if you need additional processing before data reaches the Managed OTLP Endpoint.
 
-**Self-managed, ECE, and ECK deployments**: An EDOT Collector in gateway mode is **required as part of your {{product.observability}} backend**. This Gateway Collector exposes the OTLP endpoint that edge collectors send data to, and handles essential preprocessing, including:
+**Self-managed, ECE, and ECK deployments**: An {{agent}} in gateway mode is **required as part of your {{product.observability}} backend**. This Gateway Collector exposes the OTLP endpoint that edge collectors send data to, and handles essential preprocessing, including:
 
 - Metrics aggregation for traces and logs, which improves {{product.apm}} UI performance with lower latency.
 - Format conversion for optimal storage in {{es}}.
@@ -71,9 +71,9 @@ For detailed information about Agent and Gateway modes and their specific requir
 
 ## Limitations
 
-Sending telemetry from EDOT SDKs or edge collectors directly to {{product.apm-server}}'s OpenTelemetry intake endpoint is not supported. While some data may ingest, Elastic doesn't guarantee correctness of attributes, alignment with EDOT processing pipelines, enrichment, or troubleshooting coverage.
+Sending telemetry from Elastic OTel SDKs or edge collectors directly to {{product.apm-server}}'s OpenTelemetry intake endpoint is not supported. While some data may ingest, Elastic doesn't guarantee correctness of attributes, alignment with {{edot}} processing pipelines, enrichment, or troubleshooting coverage.
 
 For supported ingestion, use:
-- **EDOT Collector (Gateway mode)** for self-managed, ECE, and ECK deployments
+- **{{agent}} (Gateway mode)** for self-managed, ECE, and ECK deployments
 - **Managed OTLP Endpoint** for {{serverless-full}} and {{ech}} deployments
 

--- a/docs/reference/architecture/index.md
+++ b/docs/reference/architecture/index.md
@@ -71,7 +71,7 @@ For detailed information about Agent and Gateway modes and their specific requir
 
 ## Limitations
 
-Sending telemetry from Elastic OTel SDKs or edge collectors directly to {{product.apm-server}}'s OpenTelemetry intake endpoint is not supported. While some data may ingest, Elastic doesn't guarantee correctness of attributes, alignment with {{edot}} processing pipelines, enrichment, or troubleshooting coverage.
+Sending telemetry from EDOT SDKs or edge collectors directly to {{product.apm-server}}'s OpenTelemetry intake endpoint is not supported. While some data may ingest, Elastic doesn't guarantee correctness of attributes, alignment with {{edot}} processing pipelines, enrichment, or troubleshooting coverage.
 
 For supported ingestion, use:
 - **{{agent}} (Gateway mode)** for self-managed, ECE, and ECK deployments

--- a/docs/reference/architecture/k8s.md
+++ b/docs/reference/architecture/k8s.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Kubernetes environments
-description: Recommended EDOT architecture for Kubernetes environments.
+description: Recommended {{edot}} architecture for Kubernetes environments.
 applies_to:
   stack:
   serverless:
@@ -47,7 +47,7 @@ This instance of the collector helps with collecting cluster level metrics which
 The gateway Collector deployed in the Kubernetes cluster centralizes OTel data from the DaemonSet and Cluster collectors. This gateway collector runs as part of your edge environment, not as part of the Elastic backend. It can be any OpenTelemetry Collector distribution as long as it forwards data using OTLP to the appropriate backend endpoint:
 
 - For {{serverless-full}} and {{ech}}: Sends OTLP data to the Managed OTLP Endpoint.
-- For self-managed, ECE, and ECK: Sends OTLP data to an EDOT Collector running in gateway mode on the backend side (refer to [backend architecture](index.md#understanding-the-elastic-observability-backend)).
+- For self-managed, ECE, and ECK: Sends OTLP data to an {{agent}} running in gateway mode on the backend side (refer to [backend architecture](index.md#understanding-the-elastic-observability-backend)).
 
 ## Deployment scenarios
 
@@ -64,7 +64,7 @@ The following sections outline the recommended architectures for different Elast
 
 ![K8s-Serverless](../images/k8s-serverless.png)
 
-For a Kubernetes setup, the gateway Collector in your cluster sends OTLP data directly to the Managed OTLP Endpoint. There is no need for an EDOT gateway collector on the backend side. You can optionally deploy an EDOT Collector in gateway mode as part of your edge environment if you need additional processing before data reaches the Managed OTLP Endpoint.
+For a Kubernetes setup, the gateway Collector in your cluster sends OTLP data directly to the Managed OTLP Endpoint. There is no need for an {{agent}} in gateway mode on the backend side. You can optionally deploy an {{agent}} in gateway mode as part of your edge environment if you need additional processing before data reaches the Managed OTLP Endpoint.
 ::::
 
 ::::{applies-item} ech:
@@ -75,24 +75,24 @@ You need an {{ech}} deployment version 9.0 or later.
 
 {{ech}} provides a [Managed OTLP Endpoint](/reference/managed-inputs/managed-otlp-endpoint.md) for ingestion of OpenTelemetry data.
 
-For a Kubernetes setup, the gateway Collector in your cluster sends OTLP data directly to the Managed OTLP Endpoint. There is no need for an EDOT gateway collector on the backend side.
+For a Kubernetes setup, the gateway Collector in your cluster sends OTLP data directly to the Managed OTLP Endpoint. There is no need for an {{agent}} in gateway mode on the backend side.
 
 ![K8s-ech](../images/k8s-ech.png)
 ::::
 
 ::::{applies-item} { eck:, ece:, self: }
-With a self-managed deployment, you need an EDOT Collector running in gateway mode as part of your {{product.observability}} backend (not in the Kubernetes cluster). This backend gateway collector receives OTLP data from the Kubernetes gateway collector and ingests it into {{es}}.
+With a self-managed deployment, you need an {{agent}} running in gateway mode as part of your {{product.observability}} backend (not in the Kubernetes cluster). This backend gateway collector receives OTLP data from the Kubernetes gateway collector and ingests it into {{es}}.
 
 ![K8s-self-managed](../images/k8s-self-managed.png)
 
 The backend gateway Collector processes {{product.apm}} data and logs to improve latency on solution UIs before ingesting into {{es}}.
 
-The Kubernetes cluster components (DaemonSet collectors, Cluster collectors, gateway collector, and OTel SDKs) can all use fully vendor-agnostic or upstream OpenTelemetry components. Only the backend gateway Collector needs to be either an EDOT Collector or a [custom, EDOT-like Collector](elastic-agent://reference/edot-collector/custom-collector.md) containing the [required components and preprocessing pipelines](elastic-agent://reference/edot-collector/config/default-config-k8s.md#direct-ingestion-into-elasticsearch).
+The Kubernetes cluster components (DaemonSet collectors, Cluster collectors, gateway collector, and OTel SDKs) can all use fully vendor-agnostic or upstream OpenTelemetry components. Only the backend gateway Collector needs to be either an {{agent}} or a [custom, {{edot}}-like Collector](elastic-agent://reference/edot-collector/custom-collector.md) containing the [required components and preprocessing pipelines](elastic-agent://reference/edot-collector/config/default-config-k8s.md#direct-ingestion-into-elasticsearch).
 
 :::{note}
-Compared to [Elastic's classic ingestion paths](docs-content://solutions/observability/apm/use-opentelemetry-with-apm.md) for OTel data, with the EDOT gateway Collector there is no need for {{product.apm-server}} anymore.
+Compared to [Elastic's classic ingestion paths](docs-content://solutions/observability/apm/use-opentelemetry-with-apm.md) for OTel data, with the {{agent}} in gateway mode there is no need for {{product.apm-server}} anymore.
 
-Refer to [EDOT data streams compared to classic {{product.apm}}](../compatibility/data-streams.md) for a detailed comparison of data streams, mappings, and storage models.
+Refer to [{{edot}} data streams compared to classic {{product.apm}}](../compatibility/data-streams.md) for a detailed comparison of data streams, mappings, and storage models.
 :::
 
 ::::

--- a/docs/reference/architecture/kafka.md
+++ b/docs/reference/architecture/kafka.md
@@ -34,7 +34,7 @@ flowchart LR
 ```
 
 In this model:
-- An edge gateway collector receives OTLP from applications (for example, Elastic OTel SDKs or other OTLP-compatible SDKs) and exports OTLP payloads to Kafka.
+- An edge gateway collector receives OTLP from applications (for example, EDOT SDKs or other OTLP-compatible SDKs) and exports OTLP payloads to Kafka.
 - An {{edot}} backend collector consumes OTLP payloads from Kafka and exports to {{es}}.
 
 ### {{ecloud}} (Hosted/Serverless) using mOTLP [elastic-cloud-motlp]

--- a/docs/reference/architecture/kafka.md
+++ b/docs/reference/architecture/kafka.md
@@ -35,7 +35,7 @@ flowchart LR
 
 In this model:
 - An edge gateway collector receives OTLP from applications (for example, EDOT SDKs or other OTLP-compatible SDKs) and exports OTLP payloads to Kafka.
-- An {{edot}} backend collector consumes OTLP payloads from Kafka and exports to {{es}}.
+- An {{agent}} backend collector consumes OTLP payloads from Kafka and exports to {{es}}.
 
 ### {{ecloud}} (Hosted/Serverless) using mOTLP [elastic-cloud-motlp]
 
@@ -50,7 +50,7 @@ flowchart LR
 ```
 
 In this model:
-- An {{edot}} backend collector consumes OTLP payloads from Kafka and exports to the {{ecloud}} Managed OTLP endpoint (mOTLP) using the OTLP/HTTP exporter.
+- An {{agent}} backend collector consumes OTLP payloads from Kafka and exports to the {{ecloud}} Managed OTLP endpoint (mOTLP) using the OTLP/HTTP exporter.
 
 ## Components [components]
 

--- a/docs/reference/architecture/kafka.md
+++ b/docs/reference/architecture/kafka.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Kafka ingest pipelines
-description: Use Kafka as a transport buffer in EDOT ingest pipelines for self-managed Elasticsearch or Elastic Cloud Managed OTLP (mOTLP).
+description: Use Kafka as a transport buffer in {{edot}} ingest pipelines for self-managed Elasticsearch or Elastic Cloud Managed OTLP (mOTLP).
 applies_to:
   stack:
   serverless:
@@ -11,7 +11,7 @@ products:
   - id: edot-collector
 ---
 
-# Kafka-based ingest pipelines with EDOT [kafka-ingest-pipelines-edot]
+# Kafka-based ingest pipelines with {{edot}} [kafka-ingest-pipelines-edot]
 
 Kafka can act as a transport buffer between telemetry sources (applications and edge collectors) and your backend, decoupling production from ingestion. Use this pattern when you need buffering during outages or maintenance, independent scaling of collection and ingestion, or a shared transport layer across environments or networks.
 
@@ -34,8 +34,8 @@ flowchart LR
 ```
 
 In this model:
-- An edge gateway collector receives OTLP from applications (for example, EDOT SDKs or other OTLP-compatible SDKs) and exports OTLP payloads to Kafka.
-- An EDOT backend collector consumes OTLP payloads from Kafka and exports to {{es}}.
+- An edge gateway collector receives OTLP from applications (for example, Elastic OTel SDKs or other OTLP-compatible SDKs) and exports OTLP payloads to Kafka.
+- An {{edot}} backend collector consumes OTLP payloads from Kafka and exports to {{es}}.
 
 ### {{ecloud}} (Hosted/Serverless) using mOTLP [elastic-cloud-motlp]
 
@@ -50,15 +50,15 @@ flowchart LR
 ```
 
 In this model:
-- An EDOT backend collector consumes OTLP payloads from Kafka and exports to the {{ecloud}} Managed OTLP endpoint (mOTLP) using the OTLP/HTTP exporter.
+- An {{edot}} backend collector consumes OTLP payloads from Kafka and exports to the {{ecloud}} Managed OTLP endpoint (mOTLP) using the OTLP/HTTP exporter.
 
 ## Components [components]
 
-These pipelines rely on the following EDOT Collector components:
+These pipelines rely on the following {{agent}} components:
 - `kafkaexporter` to write OTLP payloads to Kafka.
 - `kafkareceiver` to read OTLP payloads from Kafka.
 
-For EDOT, only the `otlp_proto` and `otlp_json` encodings are supported for the Kafka receiver and exporter. Partitioning options (for example, `partition_traces_by_id`) are not supported. Refer to the [EDOT Collector components list](elastic-agent://reference/edot-collector/components.md) for the full list and support notes.
+For {{edot}}, only the `otlp_proto` and `otlp_json` encodings are supported for the Kafka receiver and exporter. Partitioning options (for example, `partition_traces_by_id`) are not supported. Refer to the [{{agent}} components list](elastic-agent://reference/edot-collector/components.md) for the full list and support notes.
 
 ## Example configuration [example-configuration]
 
@@ -184,4 +184,4 @@ service:
 
 Monitor backpressure and export failures on both the edge gateway collector and the backend collector. A Kafka buffer can mask downstream ingestion problems until retention is exhausted. To avoid it, size retention and partitions for peak ingest and expected outage windows. 
 
-For {{product.apm}} UI optimizations on self-managed backends, align the backend collector's mode and processors with the recommended EDOT gateway architecture for your deployment.
+For {{product.apm}} UI optimizations on self-managed backends, align the backend collector's mode and processors with the recommended {{edot}} gateway architecture for your deployment.

--- a/docs/reference/central-configuration.md
+++ b/docs/reference/central-configuration.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Central configuration
-description: Reference documentation for the central configuration of Elastic OTel SDKs.
+description: Reference documentation for the central configuration of EDOT SDKs.
 applies_to:
   stack: preview 9.1+
   serverless: unavailable
@@ -10,32 +10,32 @@ products:
   - id: edot-collector
 ---
 
-# Central configuration for Elastic OTel SDKs
+# Central configuration for EDOT SDKs
 
-Manage Elastic OTel SDKs through the {{product.apm-agent}} Central Configuration feature in the Applications UI. Changes are automatically propagated to the deployed Elastic OTel SDKs. Refer to [{{product.apm-agent}} Central Configuration](docs-content://solutions/observability/apm/apm-agent-central-configuration.md) for more information.
+Manage EDOT SDKs through the {{product.apm-agent}} Central Configuration feature in the Applications UI. Changes are automatically propagated to the deployed EDOT SDKs. Refer to [{{product.apm-agent}} Central Configuration](docs-content://solutions/observability/apm/apm-agent-central-configuration.md) for more information.
 
 This feature implements the Open Agent Management Protocol (OpAMP). Refer to [Open Agent Management Protocol
 ](https://opentelemetry.io/docs/specs/opamp/) for more information.
 
 ## Architecture
 
-The central configuration architecture lets you manage fleets of Elastic OTel SDKs remotely. The data flow, illustrated in this diagram, shows how configuration changes propagate from a central management point to each individual agent.
+The central configuration architecture lets you manage fleets of EDOT SDKs remotely. The data flow, illustrated in this diagram, shows how configuration changes propagate from a central management point to each individual agent.
 
 :::{image} ./images/central-config-edot.png
 :alt: Diagram of Central config architecture
 :::
 
-The process starts within {{product.kibana}}, where administrators create and manage settings for the Elastic OTel SDKs. Once defined, settings are written to and persisted in {{es}}, which acts as the single source of truth. The {{agent}}, when configured in Gateway mode, includes the Elastic {{product.apm}} Config Extension, which reads the SDK settings from {{product.elasticsearch}}, making them available for distribution.
+The process starts within {{product.kibana}}, where administrators create and manage settings for the EDOT SDKs. Once defined, settings are written to and persisted in {{es}}, which acts as the single source of truth. The {{agent}}, when configured in Gateway mode, includes the Elastic {{product.apm}} Config Extension, which reads the SDK settings from {{product.elasticsearch}}, making them available for distribution.
 
-Each Elastic OTel SDK contains an embedded OpAMP Client. Following the Open Agent Management Protocol (OpAMP), these clients periodically poll the OpAMP server, bundled with the Collector's {{product.apm}} Config Extension, over HTTP. This polling action allows the SDKs to retrieve the latest configuration updates, enabling dynamic and centralized control over their behavior without requiring manual intervention or redeployment.
+Each EDOT SDK contains an embedded OpAMP Client. Following the Open Agent Management Protocol (OpAMP), these clients periodically poll the OpAMP server, bundled with the Collector's {{product.apm}} Config Extension, over HTTP. This polling action allows the SDKs to retrieve the latest configuration updates, enabling dynamic and centralized control over their behavior without requiring manual intervention or redeployment.
 
 ## Prerequisites
 
-To use {{product.apm-agent}} Central Configuration for Elastic OTel SDKs, you need:
+To use {{product.apm-agent}} Central Configuration for EDOT SDKs, you need:
 
 * An Elastic self-managed or {{ecloud}} deployment, version 9.1 or later.
 * A standalone [{{agent}}](elastic-agent://reference/edot-collector/index.md), in either Agent or Collector mode.
-* Elastic OTel SDKs instrumenting your application.
+* EDOT SDKs instrumenting your application.
 
 The following versions of {{edot}} and {{stack}} support central configuration:
 
@@ -43,13 +43,13 @@ The following versions of {{edot}} and {{stack}} support central configuration:
 |-----------|----------------|
 | {{kib}} | 9.1 or later |
 | {{agent}} | 8.19, 9.1 or later |
-| Elastic OTel Android | 1.2.0 or later |
-| Elastic OTel iOS | 1.4.0 or later |
-| Elastic OTel Java | 1.5.0 or later |
-| Elastic OTel .NET | 1.4.0 or later |
-| Elastic OTel Node.js | 1.2.0 or later |
-| Elastic OTel PHP | 1.1.1 or later |
-| Elastic OTel Python | 1.4.0 or later |
+| EDOT Android | 1.2.0 or later |
+| EDOT iOS | 1.4.0 or later |
+| EDOT Java | 1.5.0 or later |
+| EDOT .NET | 1.4.0 or later |
+| EDOT Node.js | 1.2.0 or later |
+| EDOT PHP | 1.1.1 or later |
+| EDOT Python | 1.4.0 or later |
 
 ::::{note}
 Serverless deployments are not supported.
@@ -57,7 +57,7 @@ Serverless deployments are not supported.
 
 ## Activate central configuration
 
-To activate {{product.apm-agent}} Central Configuration for Elastic OTel SDKs, follow these steps.
+To activate {{product.apm-agent}} Central Configuration for EDOT SDKs, follow these steps.
 
 ::::::{stepper}
 
@@ -69,7 +69,7 @@ You need a valid {{es}} API key to authenticate to the {{es}} endpoint.
 
 :::::{step} Create an Elasticsearch API key for central configuration
 
-Create an API key with the `config_agent:read` privilege. Elastic OTel SDKs use this API key, and the Collector validates it.
+Create an API key with the `config_agent:read` privilege. EDOT SDKs use this API key, and the Collector validates it.
 
 Use the following API request to generate the key:
 
@@ -105,7 +105,7 @@ POST /_security/api_key
 ::::{note}
 The {{agent}} doesn't store or embed the {{es}} API key.
 
-Each Elastic OTel SDK must send its own API key in the `Authorization` header (for example: `Authorization: ApiKey <Base64(id:key)>`).
+Each EDOT SDK must send its own API key in the `Authorization` header (for example: `Authorization: ApiKey <Base64(id:key)>`).
 
 The `apikeyauth` extension only validates this API key against {{es}}, ensuring it includes the `config_agent:read` privilege with `resources: ["*"]`.
 ::::
@@ -174,19 +174,19 @@ export ELASTIC_OTEL_OPAMP_HEADERS="Authorization=ApiKey an_api_key"
 Restart the instrumented application to apply the changes.
 
 :::{important}
-Support for the `ELASTIC_OTEL_OPAMP_HEADERS` environment variable depends on each SDK. Refer to the configuration reference of each Elastic OTel SDK for more information.
+Support for the `ELASTIC_OTEL_OPAMP_HEADERS` environment variable depends on each SDK. Refer to the configuration reference of each EDOT SDK for more information.
 :::
 
 :::::
 
-:::::{step} Check that the Elastic OTel SDK shows up
+:::::{step} Check that the EDOT SDK shows up
 
-Allow time for the Elastic OTel SDK to appear in {{kib}} under Agent Configuration.
+Allow time for the EDOT SDK to appear in {{kib}} under Agent Configuration.
 
 1. Go to **{{kib}}** → **Observability** → **Applications** and select a service.
 2. Select **Settings** and go to **Agent Configuration**.
 
-Your application must produce and send telemetry data for the Elastic OTel SDK to appear in Agent Configuration. This is because central configuration requires an application name as the key, which can't be defined until the application name is associated with the Elastic OTel SDK agent after receiving telemetry.
+Your application must produce and send telemetry data for the EDOT SDK to appear in Agent Configuration. This is because central configuration requires an application name as the key, which can't be defined until the application name is associated with the EDOT SDK agent after receiving telemetry.
 
 :::{note}
 Central configuration uses the `service.name` and `deployment.environment.name` OpenTelemetry resource attributes to target specific instances with a configuration. If no environment is specified, the central configuration feature will match `All` as the environment.
@@ -198,15 +198,15 @@ Central configuration uses the `service.name` and `deployment.environment.name` 
 
 ## Supported settings
 
-For a list of settings that you can configure through {{product.apm-agent}} Central Configuration, refer to the configuration reference of each Elastic OTel SDK:
+For a list of settings that you can configure through {{product.apm-agent}} Central Configuration, refer to the configuration reference of each EDOT SDK:
 
-- [Elastic OTel Android](apm-agent-android://reference/edot-android/configuration.md#central-configuration)
-- [Elastic OTel iOS](apm-agent-ios://reference/edot-ios/configuration.md#central-configuration-edot)
-- [Elastic OTel Java](elastic-otel-java://reference/edot-java/configuration.md#central-configuration)
-- [Elastic OTel .NET](elastic-otel-dotnet://reference/edot-dotnet/configuration.md)
-- [Elastic OTel Node.js](elastic-otel-node://reference/edot-node/configuration.md#central-configuration)
-- [Elastic OTel PHP](elastic-otel-php://reference/edot-php/configuration.md#central-configuration)
-- [Elastic OTel Python](elastic-otel-python://reference/edot-python/configuration.md#central-configuration)
+- [EDOT Android](apm-agent-android://reference/edot-android/configuration.md#central-configuration)
+- [EDOT iOS](apm-agent-ios://reference/edot-ios/configuration.md#central-configuration-edot)
+- [EDOT Java](elastic-otel-java://reference/edot-java/configuration.md#central-configuration)
+- [EDOT .NET](elastic-otel-dotnet://reference/edot-dotnet/configuration.md)
+- [EDOT Node.js](elastic-otel-node://reference/edot-node/configuration.md#central-configuration)
+- [EDOT PHP](elastic-otel-php://reference/edot-php/configuration.md#central-configuration)
+- [EDOT Python](elastic-otel-python://reference/edot-python/configuration.md#central-configuration)
 
 ## Advanced configuration
 
@@ -214,10 +214,10 @@ For a list of settings that you can configure through {{product.apm-agent}} Cent
 stack: preview 9.2
 ```
 
-The **Advanced Configuration** feature allows you to define custom configuration options as key-value pairs. Settings are passed directly to your Elastic OTel SDK.
+The **Advanced Configuration** feature allows you to define custom configuration options as key-value pairs. Settings are passed directly to your EDOT SDK.
 
 :::{warning}
-Use this feature with caution. An incorrect or incompatible setting might affect the behavior of the Elastic OTel SDK.
+Use this feature with caution. An incorrect or incompatible setting might affect the behavior of the EDOT SDK.
 :::
 
 ## Deactivate central configuration

--- a/docs/reference/central-configuration.md
+++ b/docs/reference/central-configuration.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Central configuration
-description: Reference documentation for the central configuration of EDOT SDKs.
+description: Reference documentation for the central configuration of Elastic OTel SDKs.
 applies_to:
   stack: preview 9.1+
   serverless: unavailable
@@ -10,46 +10,46 @@ products:
   - id: edot-collector
 ---
 
-# Central configuration for EDOT SDKs
+# Central configuration for Elastic OTel SDKs
 
-Manage {{edot}} (EDOT) SDKs through the {{product.apm-agent}} Central Configuration feature in the Applications UI. Changes are automatically propagated to the deployed EDOT SDKs. Refer to [{{product.apm-agent}} Central Configuration](docs-content://solutions/observability/apm/apm-agent-central-configuration.md) for more information.
+Manage Elastic OTel SDKs through the {{product.apm-agent}} Central Configuration feature in the Applications UI. Changes are automatically propagated to the deployed Elastic OTel SDKs. Refer to [{{product.apm-agent}} Central Configuration](docs-content://solutions/observability/apm/apm-agent-central-configuration.md) for more information.
 
 This feature implements the Open Agent Management Protocol (OpAMP). Refer to [Open Agent Management Protocol
 ](https://opentelemetry.io/docs/specs/opamp/) for more information.
 
 ## Architecture
 
-The central configuration architecture lets you manage fleets of EDOT SDKs remotely. The data flow, illustrated in this diagram, shows how configuration changes propagate from a central management point to each individual agent.
+The central configuration architecture lets you manage fleets of Elastic OTel SDKs remotely. The data flow, illustrated in this diagram, shows how configuration changes propagate from a central management point to each individual agent.
 
 :::{image} ./images/central-config-edot.png
 :alt: Diagram of Central config architecture
 :::
 
-The process starts within {{product.kibana}}, where administrators create and manage settings for the EDOT SDKs. Once defined, settings are written to and persisted in {{es}}, which acts as the single source of truth. The EDOT Collector, when configured in Gateway mode, includes the Elastic {{product.apm}} Config Extension, which reads the SDK settings from {{product.elasticsearch}}, making them available for distribution.
+The process starts within {{product.kibana}}, where administrators create and manage settings for the Elastic OTel SDKs. Once defined, settings are written to and persisted in {{es}}, which acts as the single source of truth. The {{agent}}, when configured in Gateway mode, includes the Elastic {{product.apm}} Config Extension, which reads the SDK settings from {{product.elasticsearch}}, making them available for distribution.
 
-Each EDOT SDK contains an embedded OpAMP Client. Following the Open Agent Management Protocol (OpAMP), these clients periodically poll the OpAMP server, bundled with the Collector's {{product.apm}} Config Extension, over HTTP. This polling action allows the SDKs to retrieve the latest configuration updates, enabling dynamic and centralized control over their behavior without requiring manual intervention or redeployment.
+Each Elastic OTel SDK contains an embedded OpAMP Client. Following the Open Agent Management Protocol (OpAMP), these clients periodically poll the OpAMP server, bundled with the Collector's {{product.apm}} Config Extension, over HTTP. This polling action allows the SDKs to retrieve the latest configuration updates, enabling dynamic and centralized control over their behavior without requiring manual intervention or redeployment.
 
 ## Prerequisites
 
-To use {{product.apm-agent}} Central Configuration for EDOT SDKs, you need:
+To use {{product.apm-agent}} Central Configuration for Elastic OTel SDKs, you need:
 
 * An Elastic self-managed or {{ecloud}} deployment, version 9.1 or later.
-* A standalone [EDOT Collector](elastic-agent://reference/edot-collector/index.md), in either Agent or Collector mode.
-* EDOT SDKs instrumenting your application.
+* A standalone [{{agent}}](elastic-agent://reference/edot-collector/index.md), in either Agent or Collector mode.
+* Elastic OTel SDKs instrumenting your application.
 
-The following versions of EDOT and {{stack}} support central configuration:
+The following versions of {{edot}} and {{stack}} support central configuration:
 
 | Component | Minimum version |
 |-----------|----------------|
 | {{kib}} | 9.1 or later |
-| EDOT Collector | 8.19, 9.1 or later |
-| EDOT Android | 1.2.0 or later |
-| EDOT iOS | 1.4.0 or later |
-| EDOT Java | 1.5.0 or later |
-| EDOT .NET | 1.4.0 or later |
-| EDOT Node.js | 1.2.0 or later |
-| EDOT PHP | 1.1.1 or later |
-| EDOT Python | 1.4.0 or later |
+| {{agent}} | 8.19, 9.1 or later |
+| Elastic OTel Android | 1.2.0 or later |
+| Elastic OTel iOS | 1.4.0 or later |
+| Elastic OTel Java | 1.5.0 or later |
+| Elastic OTel .NET | 1.4.0 or later |
+| Elastic OTel Node.js | 1.2.0 or later |
+| Elastic OTel PHP | 1.1.1 or later |
+| Elastic OTel Python | 1.4.0 or later |
 
 ::::{note}
 Serverless deployments are not supported.
@@ -57,7 +57,7 @@ Serverless deployments are not supported.
 
 ## Activate central configuration
 
-To activate {{product.apm-agent}} Central Configuration for EDOT SDKs, follow these steps.
+To activate {{product.apm-agent}} Central Configuration for Elastic OTel SDKs, follow these steps.
 
 ::::::{stepper}
 
@@ -69,7 +69,7 @@ You need a valid {{es}} API key to authenticate to the {{es}} endpoint.
 
 :::::{step} Create an Elasticsearch API key for central configuration
 
-Create an API key with the `config_agent:read` privilege. EDOT SDKs use this API key, and the Collector validates it.
+Create an API key with the `config_agent:read` privilege. Elastic OTel SDKs use this API key, and the Collector validates it.
 
 Use the following API request to generate the key:
 
@@ -103,9 +103,9 @@ POST /_security/api_key
 ```
 
 ::::{note}
-The EDOT Collector doesn't store or embed the {{es}} API key.
+The {{agent}} doesn't store or embed the {{es}} API key.
 
-Each EDOT SDK must send its own API key in the `Authorization` header (for example: `Authorization: ApiKey <Base64(id:key)>`).
+Each Elastic OTel SDK must send its own API key in the `Authorization` header (for example: `Authorization: ApiKey <Base64(id:key)>`).
 
 The `apikeyauth` extension only validates this API key against {{es}}, ensuring it includes the `config_agent:read` privilege with `resources: ["*"]`.
 ::::
@@ -144,16 +144,16 @@ POST /_security/api_key
 
 :::::
 
-:::::{step} Edit the EDOT Collector configuration
+:::::{step} Edit the {{agent}} configuration
 
-Edit the [EDOT Collector configuration](elastic-agent://reference/edot-collector/config/default-config-standalone.md#central-configuration) to activate the central configuration feature:
+Edit the [{{agent}} configuration](elastic-agent://reference/edot-collector/config/default-config-standalone.md#central-configuration) to activate the central configuration feature:
 
 :::{include} _snippets/edot-collector-auth.md
 :::
 
 Restart the Elastic Agent to also restart the Collector and apply the changes.
 
-Refer to [Secure connection](elastic-agent://reference/edot-collector/config/default-config-standalone.md#secure-connection) if you need to secure the connection between the EDOT Collector and Elastic using TLS or mutual TLS.
+Refer to [Secure connection](elastic-agent://reference/edot-collector/config/default-config-standalone.md#secure-connection) if you need to secure the connection between the {{agent}} and Elastic using TLS or mutual TLS.
 
 :::::
 
@@ -174,19 +174,19 @@ export ELASTIC_OTEL_OPAMP_HEADERS="Authorization=ApiKey an_api_key"
 Restart the instrumented application to apply the changes.
 
 :::{important}
-Support for the `ELASTIC_OTEL_OPAMP_HEADERS` environment variable depends on each SDK. Refer to the configuration reference of each EDOT SDK for more information.
+Support for the `ELASTIC_OTEL_OPAMP_HEADERS` environment variable depends on each SDK. Refer to the configuration reference of each Elastic OTel SDK for more information.
 :::
 
 :::::
 
-:::::{step} Check that the EDOT SDK shows up
+:::::{step} Check that the Elastic OTel SDK shows up
 
-Allow time for the EDOT SDK to appear in {{kib}} under Agent Configuration.
+Allow time for the Elastic OTel SDK to appear in {{kib}} under Agent Configuration.
 
 1. Go to **{{kib}}** → **Observability** → **Applications** and select a service.
 2. Select **Settings** and go to **Agent Configuration**.
 
-Your application must produce and send telemetry data for the EDOT SDK to appear in Agent Configuration. This is because central configuration requires an application name as the key, which can't be defined until the application name is associated with the EDOT SDK agent after receiving telemetry.
+Your application must produce and send telemetry data for the Elastic OTel SDK to appear in Agent Configuration. This is because central configuration requires an application name as the key, which can't be defined until the application name is associated with the Elastic OTel SDK agent after receiving telemetry.
 
 :::{note}
 Central configuration uses the `service.name` and `deployment.environment.name` OpenTelemetry resource attributes to target specific instances with a configuration. If no environment is specified, the central configuration feature will match `All` as the environment.
@@ -198,15 +198,15 @@ Central configuration uses the `service.name` and `deployment.environment.name` 
 
 ## Supported settings
 
-For a list of settings that you can configure through {{product.apm-agent}} Central Configuration, refer to the configuration reference of each EDOT SDK:
+For a list of settings that you can configure through {{product.apm-agent}} Central Configuration, refer to the configuration reference of each Elastic OTel SDK:
 
-- [EDOT Android](apm-agent-android://reference/edot-android/configuration.md#central-configuration)
-- [EDOT iOS](apm-agent-ios://reference/edot-ios/configuration.md#central-configuration-edot)
-- [EDOT Java](elastic-otel-java://reference/edot-java/configuration.md#central-configuration)
-- [EDOT .NET](elastic-otel-dotnet://reference/edot-dotnet/configuration.md)
-- [EDOT Node.js](elastic-otel-node://reference/edot-node/configuration.md#central-configuration)
-- [EDOT PHP](elastic-otel-php://reference/edot-php/configuration.md#central-configuration)
-- [EDOT Python](elastic-otel-python://reference/edot-python/configuration.md#central-configuration)
+- [Elastic OTel Android](apm-agent-android://reference/edot-android/configuration.md#central-configuration)
+- [Elastic OTel iOS](apm-agent-ios://reference/edot-ios/configuration.md#central-configuration-edot)
+- [Elastic OTel Java](elastic-otel-java://reference/edot-java/configuration.md#central-configuration)
+- [Elastic OTel .NET](elastic-otel-dotnet://reference/edot-dotnet/configuration.md)
+- [Elastic OTel Node.js](elastic-otel-node://reference/edot-node/configuration.md#central-configuration)
+- [Elastic OTel PHP](elastic-otel-php://reference/edot-php/configuration.md#central-configuration)
+- [Elastic OTel Python](elastic-otel-python://reference/edot-python/configuration.md#central-configuration)
 
 ## Advanced configuration
 
@@ -214,10 +214,10 @@ For a list of settings that you can configure through {{product.apm-agent}} Cent
 stack: preview 9.2
 ```
 
-The **Advanced Configuration** feature allows you to define custom configuration options as key-value pairs. Settings are passed directly to your EDOT SDK.
+The **Advanced Configuration** feature allows you to define custom configuration options as key-value pairs. Settings are passed directly to your Elastic OTel SDK.
 
 :::{warning}
-Use this feature with caution. An incorrect or incompatible setting might affect the behavior of the EDOT SDK.
+Use this feature with caution. An incorrect or incompatible setting might affect the behavior of the Elastic OTel SDK.
 :::
 
 ## Deactivate central configuration

--- a/docs/reference/compatibility/collectors.md
+++ b/docs/reference/compatibility/collectors.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Collector distributions
-description: Compatibility and support information for EDOT Collector versions with Elastic Stack versions and operating systems.
+description: Compatibility and support information for {{agent}} versions with {{stack}} versions and operating systems.
 applies_to:
   stack:
   serverless:
@@ -11,11 +11,11 @@ products:
   - id: edot-collector
 ---
 
-# EDOT compatibility and support for OTel Collectors
+# {{edot}} compatibility and support for OTel Collectors
 
-The following table provides an overview of compatibility and support of {{edot}} Collector versions with {{stack}} (ELK) versions.
+The following table provides an overview of compatibility and support of {{agent}} versions with {{stack}} (ELK) versions.
 
-## EDOT Collector 9.x [collector-9]
+## {{agent}} 9.x [collector-9]
 
 | ELK stack version           | **ELK < 8.16** | **ELK 8.16 - 8.17** | **ELK 8.18 - 8.19** | **ELK 9.0 and later** |
 | :-------------------------- | :------------- | :------------------ | :------------------ | :---------- |
@@ -23,20 +23,20 @@ The following table provides an overview of compatibility and support of {{edot}
 | **Level of support**        | [Not supported] | [Not supported]    | [Supported]         | [Supported] |
 
 :::{note}
-If you're on {{stack}} 8.18 or 8.19 and require Elastic support, use EDOT Collector version 9.x, as this combination is officially [Supported].
+If you're on {{stack}} 8.18 or 8.19 and require Elastic support, use {{agent}} version 9.x, as this combination is officially [Supported].
 :::
 
 ### Configuration compatibility
 
-If you upgrade to EDOT Collector 9.x while running {{stack}} 8.18 or 8.19, continue using the configuration recommended for your Stack version, not the EDOT Collector 9.x default configuration. This ensures full compatibility with {{kib}} Observability applications.
+If you upgrade to {{agent}} 9.x while running {{stack}} 8.18 or 8.19, continue using the configuration recommended for your Stack version, not the {{agent}} 9.x default configuration. This ensures full compatibility with {{kib}} Observability applications.
 
 ## Operating systems
 
-The following table provides an overview of compatibility and support of EDOT Collector versions with different operating systems.
+The following table provides an overview of compatibility and support of {{agent}} versions with different operating systems.
 
-### EDOT Collector 9.x [os-collector-9]
+### {{agent}} 9.x [os-collector-9]
 
-These operating systems and distributions are [compatible] with EDOT Collector 9.x:
+These operating systems and distributions are [compatible] with {{agent}} 9.x:
 
 | OS Type | Architecture | Distribution or version                                  | Level of support     |
 | :------ | :----------- | :------------------------------------------------------- | :------------------- |
@@ -47,13 +47,13 @@ These operating systems and distributions are [compatible] with EDOT Collector 9
 | macOS   | arm64        | macOS 10.x and higher                                    | [Not supported]      |
 | Windows | amd64        | Server 2022, 2022 Core, 2019, 2019 Core, 2016, 2016 Core | [Not supported]      |
 
-The following Kubernetes distributions are [compatible] with EDOT Collector 9.x:
+The following Kubernetes distributions are [compatible] with {{agent}} 9.x:
 
 | Kubernetes  | Architecture     | Version                                                  |
 | :---------- | :--------------- | :------------------------------------------------------- |
 | Kubernetes  | amd64, arm64     | 1.33.0, 1.32.0, 1.31.0, 1.30.2, 1.29.4, 1.28.9, 1.27.16  |
 
-The EDOT Collector is compatible with GKE, EKS, and AKS. Refer to [Limitations on managed Kubernetes environments](/reference/compatibility/limitations.md#limitations-on-managed-kubernetes-environments) for more information.
+{{agent}} is compatible with GKE, EKS, and AKS. Refer to [Limitations on managed Kubernetes environments](/reference/compatibility/limitations.md#limitations-on-managed-kubernetes-environments) for more information.
 
 ### Platform-specific recommendations
 
@@ -75,17 +75,17 @@ Use the [AWS Distro for OpenTelemetry (ADOT)](https://aws-otel.github.io/docs/ge
 For AWS Lambda workloads that generate telemetry outside the function runtime, such as CloudWatch logs, use the [{{edot-cf}}](edot-cloud-forwarder-aws://reference/edot-cf-aws/index.md) instead. 
 :::
 
-## EDOT Collector components
+## {{agent}} components
 
 For information on the compatibility of each Collector component, refer to the [full list of Core and Extended components](elastic-agent://reference/edot-collector/components.md).
 
 ## Other Collector distributions
 
-Non-EDOT distributions of the OTel Collector, such as custom Collector builds, contrib Collector distributions, and so on aren't officially supported through Elastic but are technically compatible ([Compatible]) if they contain the [required OTel Collector components](elastic-agent://reference/edot-collector/custom-collector.md) and are configured like the EDOT Collector.
+Non-{{edot}} distributions of the OTel Collector, such as custom Collector builds, contrib Collector distributions, and so on aren't officially supported through Elastic but are technically compatible ([Compatible]) if they contain the [required OTel Collector components](elastic-agent://reference/edot-collector/custom-collector.md) and are configured like {{agent}}.
 
-You can retrieve required components and configuration options from the [example configuration files](https://github.com/elastic/elastic-agent/tree/v<COLLECTOR_VERSION>/internal/pkg/otel/samples/linux) for the EDOT Collector.
+You can retrieve required components and configuration options from the [example configuration files](https://github.com/elastic/elastic-agent/tree/v<COLLECTOR_VERSION>/internal/pkg/otel/samples/linux) for {{agent}}.
 
-For a comparison between EDOT and contrib OpenTelemetry components, refer to [EDOT compared to contrib](edot-vs-upstream.md).
+For a comparison between {{edot}} and contrib OpenTelemetry components, refer to [{{edot}} compared to upstream](edot-vs-upstream.md).
 
 [Incompatible]: nomenclature.md
 [Compatible]: nomenclature.md

--- a/docs/reference/compatibility/data-streams.md
+++ b/docs/reference/compatibility/data-streams.md
@@ -38,7 +38,7 @@ Metric data is stored using {{es}}'s [TSDS](docs-content://manage-data/data-stor
 * Automatic detection of metric dimensions (no need to manually define `time_series_dimension` in field mappings)
 
 
-## Comparison with classic {{product.apm}} data streams
+## Comparison with classic {{product.apm}} data streams [comparison-with-classic-apm-data-streams]
 
 This table highlights key differences between classic {{product.apm}} data streams and {{edot}} with `mapping_mode: otel`:
 

--- a/docs/reference/compatibility/data-streams.md
+++ b/docs/reference/compatibility/data-streams.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Data streams comparison
-description: Learn how EDOT optimizes telemetry storage and query performance in Elastic Observability compared to classic APM and ECS-based integrations. 
+description: Learn how {{edot}} optimizes telemetry storage and query performance in {{product.observability}} compared to classic APM and ECS-based integrations. 
 applies_to:
   stack:
   serverless:
@@ -12,15 +12,15 @@ products:
   - id: edot-sdk
 ---
 
-# OpenTelemetry data streams compared to classic APM and ECS-based integrations
+# OpenTelemetry data streams compared to classic {{product.apm}} and ECS-based integrations
 
-The {{edot}} (EDOT) stores telemetry data using a storage model optimized for OpenTelemetry signals. When `mapping_mode: otel` is enabled on the {{es}} exporter (which is the default setting), EDOT writes logs, traces, and metrics to specialized data streams aligned with OpenTelemetry specifications.
+{{edot}} stores telemetry data using a storage model optimized for OpenTelemetry signals. When `mapping_mode: otel` is enabled on the {{es}} exporter (which is the default setting), {{edot}} writes logs, traces, and metrics to specialized data streams aligned with OpenTelemetry specifications.
 
 This architecture is designed for scalable observability workloads. It supports dynamic attributes, reduces mapping complexity, and avoids issues like mapping explosions or manual dimension setup.
 
-EDOT uses {{es}}’s [Logs data stream (LogsDB)](docs-content://manage-data/data-store/data-streams/logs-data-stream.md) and [Time Series Data Streams (TSDS)](docs-content://manage-data/data-store/data-streams/time-series-data-stream-tsds.md) as storage backends. These are purpose-built to handle the scale and variety of observability data and improve the storage efficiency.
+{{edot}} uses {{es}}'s [Logs data stream (LogsDB)](docs-content://manage-data/data-store/data-streams/logs-data-stream.md) and [Time Series Data Streams (TSDS)](docs-content://manage-data/data-store/data-streams/time-series-data-stream-tsds.md) as storage backends. These are purpose-built to handle the scale and variety of observability data and improve the storage efficiency.
 
-This page provides a detailed comparison of EDOT data streams with classic {{product.apm}} and ECS-based integrations. For a practical reference on which data streams EDOT uses, exporter behavior, and storage engines, see [EDOT data streams](../data-streams.md).
+This page provides a detailed comparison of {{edot}} data streams with classic {{product.apm}} and ECS-based integrations. For a practical reference on which data streams {{edot}} uses, exporter behavior, and storage engines, see [{{edot}} data streams](../data-streams.md).
 
 ## Logs and traces in LogsDB
 
@@ -31,26 +31,26 @@ Log and trace data is stored in [LogsDB](docs-content://manage-data/data-store/d
 
 ## Metrics in TSDS
 
-Metric data is stored using {{es}}’s [TSDS](docs-content://manage-data/data-store/data-streams/time-series-data-stream-tsds.md). Benefits include:
+Metric data is stored using {{es}}'s [TSDS](docs-content://manage-data/data-store/data-streams/time-series-data-stream-tsds.md). Benefits include:
 
 * Efficient storage using columnar compression  
 * Fast aggregations 
 * Automatic detection of metric dimensions (no need to manually define `time_series_dimension` in field mappings)
 
 
-## Comparison with classic APM data streams
+## Comparison with classic {{product.apm}} data streams
 
-This table highlights key differences between classic Elastic APM data streams and EDOT with `mapping_mode: otel`:
+This table highlights key differences between classic {{product.apm}} data streams and {{edot}} with `mapping_mode: otel`:
 
-| Feature                   | Classic {{product.apm}} (ECS-based)                                                                                                          | EDOT (`mapping_mode: otel`)                                                                                                          |
+| Feature                   | Classic {{product.apm}} (ECS-based)                                                                                                          | {{edot}} (`mapping_mode: otel`)                                                                                                          |
 |---|---|---|
 | Index mode | General-purpose data streams (logs, traces, metrics) <br><br> TSDS is not supported for classic {{product.apm}}. | LogsDB (logs/traces), TSDS (metrics) |
 | Mapping style | Nested objects are mapped as structured fields. Some exceptions exist, such as `labels.*` and `numeric_labels.*`, where dots in field names are replaced with underscores. <br><br> ECS supports multiple field types (keyword, long, double, date, boolean, and so on) as defined in the schema. | Native OpenTelemetry fields with `passthrough`, preserving types and structure. |
-| Attribute handling | Dynamic mapping. Custom attributes are stored under `labels.*` (strings) or `numeric_labels.*` (numbers); dots in field names are replaced with underscores. <br><br> See [Document examples - classic {{product.apm}}](#classic-apm) | Dynamic mapping with native types under `attributes.*`, preserving dots in field names. <br><br> See [Document examples - EDOT](#edot) |
+| Attribute handling | Dynamic mapping. Custom attributes are stored under `labels.*` (strings) or `numeric_labels.*` (numbers); dots in field names are replaced with underscores. <br><br> See [Document examples - classic {{product.apm}}](#classic-apm) | Dynamic mapping with native types under `attributes.*`, preserving dots in field names. <br><br> See [Document examples - {{edot}}](#edot) |
 
-### Query compatibility with classic APM data streams
+### Query compatibility with classic {{product.apm}} data streams
 
-EDOT is designed to make OpenTelemetry data queryable using many of the same field names as classic {{product.apm}} (ECS-based) data streams. This helps preserve compatibility with existing dashboards, saved searches, and queries.
+{{edot}} is designed to make OpenTelemetry data queryable using many of the same field names as classic {{product.apm}} (ECS-based) data streams. This helps preserve compatibility with existing dashboards, saved searches, and queries.
 
 Query compatibility is achieved through:
 
@@ -71,7 +71,7 @@ Refer to [ECS & OpenTelemetry](ecs://reference/ecs-opentelemetry.md) for details
 
 ### Document examples
 
-#### Classic APM
+#### Classic {{product.apm}} [classic-apm]
 
 ```yaml
 "@timestamp": "2025-08-14T05:29:43.922Z"
@@ -96,7 +96,7 @@ log:
   level: INFO
 ```
 
-#### EDOT
+#### {{edot}} [edot]
 
 ```yaml
 "@timestamp": "2025-08-14T05:29:43.922Z"
@@ -122,12 +122,12 @@ severity_text: INFO
 
 ## Comparison with ECS-based integrations
 
-While classic {{product.apm}} and EDOT represent two ingestion paths for application telemetry, Elastic’s integrations (for example Nginx, MySQL, Kubernetes) also produce ECS-based data streams for logs, metrics, and events. These use ECS mappings and integration-specific pipelines optimized for their domain.
+While classic {{product.apm}} and {{edot}} represent two ingestion paths for application telemetry, Elastic's integrations (for example Nginx, MySQL, Kubernetes) also produce ECS-based data streams for logs, metrics, and events. These use ECS mappings and integration-specific pipelines optimized for their domain.
 
 | Stream type | Typical field layout | Custom attributes / dot notation |
 |--------------|----------------------|----------------------------------|
 | **Integration ECS-based** | Uses ECS mapping tailored by integration. Custom fields are added under ECS-structured objects or `.custom` objects. Dots in field names are often disallowed or normalized to underscores. | Example: `host.os.name`, `nginx.access.time` rewritten to `nginx_access_time` |
-| **EDOT (OTel + passthrough)** | Stores OTel-native nested object structure (`resource.attributes.*`, `attributes.*`). Uses `passthrough` to expose fields at the top level for query compatibility. | Example: `attributes.cart.items: 42`, `resource.attributes.service.name: "checkout-service"` |
+| **{{edot}} (OTel + passthrough)** | Stores OTel-native nested object structure (`resource.attributes.*`, `attributes.*`). Uses `passthrough` to expose fields at the top level for query compatibility. | Example: `attributes.cart.items: 42`, `resource.attributes.service.name: "checkout-service"` |
 
 ### Integration example (Nginx access logs)
 
@@ -150,7 +150,7 @@ user:
 
 ## Summary of all data stream types
 
-| Feature | Classic {{product.apm}} (ECS-based) | Integration ECS-based streams | EDOT (`mapping_mode: otel`) |
+| Feature | Classic {{product.apm}} (ECS-based) | Integration ECS-based streams | {{edot}} (`mapping_mode: otel`) |
 |----------|-------------------------|-------------------------------|-----------------------------|
 | **Index mode** | General-purpose data streams (logs, traces, metrics); TSDS not supported | ECS-style data streams (logs, metrics, events) using integrations | LogsDB for logs/traces, TSDS for metrics |
 | **Mapping style** | ECS object mappings; nested fields preserved. `labels.*` / `numeric_labels.*` flatten dots. | ECS mappings or integration-altered schemas (flattening, renaming). | OTel-native nested layout with `passthrough`, preserving types and structure. |

--- a/docs/reference/compatibility/edot-vs-upstream.md
+++ b/docs/reference/compatibility/edot-vs-upstream.md
@@ -31,7 +31,7 @@ The following table summarizes the key differences:
 | Deployment | Same deployment methods as upstream, with ready-to-use default configurations. | Users provide their own configuration. |
 | Central management | Central configuration of SDKs and Collectors through [OpAMP](/reference/central-configuration.md), including a managed OpAMP server. | OpAMP protocol is supported, but no managed server is provided. |
 | Compatibility | Fully tested with {{stack}} components. | Compatible, but not tested or supported by Elastic. |
-| Updates | {{agent}} releases align with {{stack}}. Elastic OTel SDKs follow the upstream OpenTelemetry release cycle. | Follows the upstream OpenTelemetry release cycle. |
+| Updates | {{agent}} releases align with {{stack}}. EDOT SDKs follow the upstream OpenTelemetry release cycle. | Follows the upstream OpenTelemetry release cycle. |
 
 The following sections describe how this general comparison applies to each {{edot}} component.
 
@@ -45,42 +45,42 @@ The upstream OpenTelemetry project does not ship a single, recommended Collector
 
 Users who need a Collector build that differs from the standard {{agent}} can follow the [custom Collector guide](elastic-agent://reference/edot-collector/custom-collector.md), which describes the required components and preprocessing pipelines for Elastic compatibility. For the full list of components included in {{agent}}, refer to the [{{agent}} components](elastic-agent://reference/edot-collector/components.md) page.
 
-## Elastic OTel SDKs
+## EDOT SDKs
 
 OpenTelemetry language SDKs provide the instrumentation libraries that applications use to generate traces, metrics, and logs. The upstream project publishes reference SDKs for each supported language. Vendors can wrap these into [distributions](https://opentelemetry.io/docs/concepts/distributions/)  that add defaults, extensions, or vendor-specific improvements.
 
-Elastic OTel SDKs are such distributions. They maintain full compatibility with the OpenTelemetry specification and come with preselected instrumentations that enable [zero-code instrumentation](https://opentelemetry.io/docs/concepts/instrumentation/zero-code/) by default.
+EDOT SDKs are such distributions. They maintain full compatibility with the OpenTelemetry specification and come with preselected instrumentations that enable [zero-code instrumentation](https://opentelemetry.io/docs/concepts/instrumentation/zero-code/) by default.
 
-The following Elastic OTel SDKs are available:
+The following EDOT SDKs are available:
 
-- [Elastic OTel .NET](elastic-otel-dotnet://reference/edot-dotnet/index.md)
-- [Elastic OTel Java](elastic-otel-java://reference/edot-java/index.md)
-- [Elastic OTel Node.js](elastic-otel-node://reference/edot-node/index.md)
-- [Elastic OTel PHP](elastic-otel-php://reference/edot-php/index.md)
-- [Elastic OTel Python](elastic-otel-python://reference/edot-python/index.md)
-- [Elastic OTel Android](apm-agent-android://reference/edot-android/index.md)
-- [Elastic OTel iOS](apm-agent-ios://reference/edot-ios/index.md)
+- [EDOT .NET](elastic-otel-dotnet://reference/edot-dotnet/index.md)
+- [EDOT Java](elastic-otel-java://reference/edot-java/index.md)
+- [EDOT Node.js](elastic-otel-node://reference/edot-node/index.md)
+- [EDOT PHP](elastic-otel-php://reference/edot-php/index.md)
+- [EDOT Python](elastic-otel-python://reference/edot-python/index.md)
+- [EDOT Android](apm-agent-android://reference/edot-android/index.md)
+- [EDOT iOS](apm-agent-ios://reference/edot-ios/index.md)
 
-Due to current upstream limitations, some capabilities are temporarily available only in Elastic OTel SDKs. Elastic is actively working to contribute these upstream so that they become part of the standard OpenTelemetry SDKs. Refer to the [Elastic OTel SDKs overview](/reference/edot-sdks/index.md) for the full feature matrix across languages.
+Due to current upstream limitations, some capabilities are temporarily available only in EDOT SDKs. Elastic is actively working to contribute these upstream so that they become part of the standard OpenTelemetry SDKs. Refer to the [EDOT SDKs overview](/reference/edot-sdks/index.md) for the full feature matrix across languages.
 
 | Capability | Status |
 |------------|--------|
 | Inferred spans | Available in {{edot}} only. Generates spans from profiling data without manual instrumentation, closing visibility gaps that auto-instrumentation does not cover. |
 | Central configuration | Available in {{edot}} only. Manages SDK settings from {{kib}} through the {{agent}} using [OpAMP](/reference/central-configuration.md). Most SDKs apply configuration changes dynamically, without restarting or redeploying applications. |
-| Profiling integration | Available in Elastic OTel Java only. Correlates traces with continuous profiling data for deeper performance analysis. |
+| Profiling integration | Available in EDOT Java only. Correlates traces with continuous profiling data for deeper performance analysis. |
 | Crash reporting | Available in {{edot}} only. Captures native crash data on mobile platforms for post-mortem analysis. |
 
 Upstream OTel SDKs are technically [Compatible] with Elastic and can send data through the same ingestion paths, but Elastic does not provide official support or troubleshooting assistance for them. Refer to the [SDK compatibility table](sdks.md) for version-level details.
 
 :::{important}
-Elastic OTel SDKs are designed to export telemetry through the [{{agent}}](elastic-agent://reference/edot-collector/index.md) or the [{{motlp}}](/reference/managed-inputs/managed-otlp-endpoint.md). Using Elastic OTel SDKs directly with {{product.apm-server}}'s OpenTelemetry intake is not supported — attribute mapping, enrichment, and processing pipelines are not guaranteed on that path.
+EDOT SDKs are designed to export telemetry through the [{{agent}}](elastic-agent://reference/edot-collector/index.md) or the [{{motlp}}](/reference/managed-inputs/managed-otlp-endpoint.md). Using EDOT SDKs directly with {{product.apm-server}}'s OpenTelemetry intake is not supported — attribute mapping, enrichment, and processing pipelines are not guaranteed on that path.
 :::
 
 ## Kubernetes Operator
 
 {{edot}} does not ship its own Kubernetes operator. Instead, {{edot}} deployments on Kubernetes rely on the upstream [OpenTelemetry Operator](https://opentelemetry.io/docs/platforms/kubernetes/operator/), which manages Collector deployments and auto-instrumentation of workloads through Kubernetes custom resource definitions (CRDs).
 
-In an {{edot}}-based Kubernetes setup, the operator's `OpenTelemetryCollector` CRD deploys {{agent}} images as DaemonSets, Deployments, or StatefulSets, and the `Instrumentation` CRD is configured to inject Elastic OTel SDK images (for example, `docker.elastic.co/observability/elastic-otel-javaagent`) instead of the default upstream images. The operator handles the mechanics of admission webhooks and init container injection, while {{edot}} provides the container images and configurations that the operator deploys.
+In an {{edot}}-based Kubernetes setup, the operator's `OpenTelemetryCollector` CRD deploys {{agent}} images as DaemonSets, Deployments, or StatefulSets, and the `Instrumentation` CRD is configured to inject EDOT SDK images (for example, `docker.elastic.co/observability/elastic-otel-javaagent`) instead of the default upstream images. The operator handles the mechanics of admission webhooks and init container injection, while {{edot}} provides the container images and configurations that the operator deploys.
 
 This creates a dual support model. The operator itself is an upstream community project and receives community support. The {{agent}} and SDK images that the operator deploys are covered by Elastic support under the same terms as their standalone counterparts. When filing issues, distinguish between operator behavior (community support) and {{edot}} component behavior (Elastic support).
 

--- a/docs/reference/compatibility/edot-vs-upstream.md
+++ b/docs/reference/compatibility/edot-vs-upstream.md
@@ -1,6 +1,6 @@
 ---
-navigation_title: EDOT compared to upstream
-description: How Elastic Distributions of OpenTelemetry (EDOT) compare to upstream OpenTelemetry components, including Collector, SDKs, Kubernetes Operator, and more.
+navigation_title: "{{edot}} compared to upstream"
+description: How {{edot}} compare to upstream OpenTelemetry components, including Collector, SDKs, Kubernetes Operator, and more.
 applies_to:
   stack:
   serverless:
@@ -12,17 +12,17 @@ products:
   - id: edot-sdk
 ---
 
-# EDOT compared to upstream OpenTelemetry
+# {{edot}} compared to upstream
 
-[Elastic Distributions of OpenTelemetry (EDOT)](/reference/index.md) are a set of [OpenTelemetry distributions](https://opentelemetry.io/docs/concepts/distributions/) curated, tested, and supported by Elastic. Each EDOT component builds on its upstream counterpart, adding production-ready defaults, Elastic-specific capabilities, and official support backed by [Elastic's Support Policy](https://www.elastic.co/support_policy) and SLAs. 
+[{{edot}}](/reference/index.md) are a set of [OpenTelemetry distributions](https://opentelemetry.io/docs/concepts/distributions/) curated, tested, and supported by Elastic. Each {{edot}} component builds on its upstream counterpart, adding production-ready defaults, Elastic-specific capabilities, and official support backed by [Elastic's Support Policy](https://www.elastic.co/support_policy) and SLAs. 
 
-Elastic is also an active contributor to the upstream OpenTelemetry project, working to stabilize components, advance semantic conventions, and move capabilities upstream so that the broader community benefits. Elastic contributes bug fixes and improvements upstream first, and only ships fixes in EDOT ahead of upstream when there are strong reasons to do so.
+Elastic is also an active contributor to the upstream OpenTelemetry project, working to stabilize components, advance semantic conventions, and move capabilities upstream so that the broader community benefits. Elastic contributes bug fixes and improvements upstream first, and only ships fixes in {{edot}} ahead of upstream when there are strong reasons to do so.
 
-EDOT is always optional. Elastic's OTLP ingestion APIs are vendor-agnostic and preserve OpenTelemetry semantic conventions, so any upstream or third-party OpenTelemetry component that speaks OTLP can send data to the {{stack}}. Upstream components are technically [Compatible] but receive community support only. EDOT is for teams that want a supported, production-grade experience that can be a drop-in replacement for upstream OpenTelemetry components.
+{{edot}} is always optional. Elastic's OTLP ingestion APIs are vendor-agnostic and preserve OpenTelemetry semantic conventions, so any upstream or third-party OpenTelemetry component that speaks OTLP can send data to the {{stack}}. Upstream components are technically [Compatible] but receive community support only. {{edot}} is for teams that want a supported, production-grade experience that can be a drop-in replacement for upstream OpenTelemetry components.
 
 The following table summarizes the key differences:
 
-| Aspect | EDOT | Upstream |
+| Aspect | {{edot}} | Upstream |
 |--------|------|----------|
 | Configuration | Pre-configured defaults for {{product.observability}}. | Requires manual component selection and configuration. |
 | Support | Official Elastic support with SLAs. | Community support. |
@@ -31,74 +31,74 @@ The following table summarizes the key differences:
 | Deployment | Same deployment methods as upstream, with ready-to-use default configurations. | Users provide their own configuration. |
 | Central management | Central configuration of SDKs and Collectors through [OpAMP](/reference/central-configuration.md), including a managed OpAMP server. | OpAMP protocol is supported, but no managed server is provided. |
 | Compatibility | Fully tested with {{stack}} components. | Compatible, but not tested or supported by Elastic. |
-| Updates | EDOT Collector releases align with {{stack}}. EDOT SDKs follow the upstream OpenTelemetry release cycle. | Follows the upstream OpenTelemetry release cycle. |
+| Updates | {{agent}} releases align with {{stack}}. Elastic OTel SDKs follow the upstream OpenTelemetry release cycle. | Follows the upstream OpenTelemetry release cycle. |
 
-The following sections describe how this general comparison applies to each EDOT component.
+The following sections describe how this general comparison applies to each {{edot}} component.
 
-## EDOT Collector
+## {{agent}}
 
 The upstream OpenTelemetry project does not ship a single, recommended Collector distribution for production use. Instead, it offers a core Collector and a contrib Collector whose components have [mixed stability levels](https://opentelemetry.io/docs/collector/). Assembling a production-ready Collector from these components requires careful selection, configuration, and testing.
 
-EDOT Collector is a curated distribution that eliminates this assembly step. It includes specific components and configurations optimized for {{product.observability}}, and it ships with Elastic-specific components that are not available in contrib, such as the `elasticsearchexporter` for native ingestion into {{es}} and the `elasticapmintakereceiver` for backward-compatible {{product.apm}} intake. These components are developed by Elastic with the intent of contributing them upstream over time.
+{{agent}} is a curated distribution that eliminates this assembly step. It includes specific components and configurations optimized for {{product.observability}}, and it ships with Elastic-specific components that are not available in contrib, such as the `elasticsearchexporter` for native ingestion into {{es}} and the `elasticapmintakereceiver` for backward-compatible {{product.apm}} intake. These components are developed by Elastic with the intent of contributing them upstream over time.
 
-EDOT Collector ships with [default configurations](elastic-agent://reference/edot-collector/config/default-config-standalone.md) for common deployment scenarios, including [standalone](elastic-agent://reference/edot-collector/config/default-config-standalone.md) and [Kubernetes](elastic-agent://reference/edot-collector/config/default-config-k8s.md). In self-managed {{stack}} deployments, the EDOT Collector running in [gateway mode](elastic-agent://reference/edot-collector/modes.md) replaces {{product.apm-server}} for OTel-native data ingestion, handling metrics aggregation and format conversion before writing to {{es}}.
+{{agent}} ships with [default configurations](elastic-agent://reference/edot-collector/config/default-config-standalone.md) for common deployment scenarios, including [standalone](elastic-agent://reference/edot-collector/config/default-config-standalone.md) and [Kubernetes](elastic-agent://reference/edot-collector/config/default-config-k8s.md). In self-managed {{stack}} deployments, the {{agent}} running in [gateway mode](elastic-agent://reference/edot-collector/modes.md) replaces {{product.apm-server}} for OTel-native data ingestion, handling metrics aggregation and format conversion before writing to {{es}}.
 
-Users who need a Collector build that differs from the standard EDOT Collector can follow the [custom Collector guide](elastic-agent://reference/edot-collector/custom-collector.md), which describes the required components and preprocessing pipelines for Elastic compatibility. For the full list of components included in EDOT Collector, refer to the [EDOT Collector components](elastic-agent://reference/edot-collector/components.md) page.
+Users who need a Collector build that differs from the standard {{agent}} can follow the [custom Collector guide](elastic-agent://reference/edot-collector/custom-collector.md), which describes the required components and preprocessing pipelines for Elastic compatibility. For the full list of components included in {{agent}}, refer to the [{{agent}} components](elastic-agent://reference/edot-collector/components.md) page.
 
-## EDOT SDKs
+## Elastic OTel SDKs
 
 OpenTelemetry language SDKs provide the instrumentation libraries that applications use to generate traces, metrics, and logs. The upstream project publishes reference SDKs for each supported language. Vendors can wrap these into [distributions](https://opentelemetry.io/docs/concepts/distributions/)  that add defaults, extensions, or vendor-specific improvements.
 
-EDOT SDKs are such distributions. They maintain full compatibility with the OpenTelemetry specification and come with preselected instrumentations that enable [zero-code instrumentation](https://opentelemetry.io/docs/concepts/instrumentation/zero-code/) by default.
+Elastic OTel SDKs are such distributions. They maintain full compatibility with the OpenTelemetry specification and come with preselected instrumentations that enable [zero-code instrumentation](https://opentelemetry.io/docs/concepts/instrumentation/zero-code/) by default.
 
-The following EDOT SDKs are available:
+The following Elastic OTel SDKs are available:
 
-- [EDOT .NET](elastic-otel-dotnet://reference/edot-dotnet/index.md)
-- [EDOT Java](elastic-otel-java://reference/edot-java/index.md)
-- [EDOT Node.js](elastic-otel-node://reference/edot-node/index.md)
-- [EDOT PHP](elastic-otel-php://reference/edot-php/index.md)
-- [EDOT Python](elastic-otel-python://reference/edot-python/index.md)
-- [EDOT Android](apm-agent-android://reference/edot-android/index.md)
-- [EDOT iOS](apm-agent-ios://reference/edot-ios/index.md)
+- [Elastic OTel .NET](elastic-otel-dotnet://reference/edot-dotnet/index.md)
+- [Elastic OTel Java](elastic-otel-java://reference/edot-java/index.md)
+- [Elastic OTel Node.js](elastic-otel-node://reference/edot-node/index.md)
+- [Elastic OTel PHP](elastic-otel-php://reference/edot-php/index.md)
+- [Elastic OTel Python](elastic-otel-python://reference/edot-python/index.md)
+- [Elastic OTel Android](apm-agent-android://reference/edot-android/index.md)
+- [Elastic OTel iOS](apm-agent-ios://reference/edot-ios/index.md)
 
-Due to current upstream limitations, some capabilities are temporarily available only in EDOT SDKs. Elastic is actively working to contribute these upstream so that they become part of the standard OpenTelemetry SDKs. Refer to the [EDOT SDKs overview](/reference/edot-sdks/index.md) for the full feature matrix across languages.
+Due to current upstream limitations, some capabilities are temporarily available only in Elastic OTel SDKs. Elastic is actively working to contribute these upstream so that they become part of the standard OpenTelemetry SDKs. Refer to the [Elastic OTel SDKs overview](/reference/edot-sdks/index.md) for the full feature matrix across languages.
 
 | Capability | Status |
 |------------|--------|
-| Inferred spans | Available in EDOT only. Generates spans from profiling data without manual instrumentation, closing visibility gaps that auto-instrumentation does not cover. |
-| Central configuration | Available in EDOT only. Manages SDK settings from {{kib}} through the EDOT Collector using [OpAMP](/reference/central-configuration.md). Most SDKs apply configuration changes dynamically, without restarting or redeploying applications. |
-| Profiling integration | Available in EDOT Java only. Correlates traces with continuous profiling data for deeper performance analysis. |
-| Crash reporting | Available in EDOT only. Captures native crash data on mobile platforms for post-mortem analysis. |
+| Inferred spans | Available in {{edot}} only. Generates spans from profiling data without manual instrumentation, closing visibility gaps that auto-instrumentation does not cover. |
+| Central configuration | Available in {{edot}} only. Manages SDK settings from {{kib}} through the {{agent}} using [OpAMP](/reference/central-configuration.md). Most SDKs apply configuration changes dynamically, without restarting or redeploying applications. |
+| Profiling integration | Available in Elastic OTel Java only. Correlates traces with continuous profiling data for deeper performance analysis. |
+| Crash reporting | Available in {{edot}} only. Captures native crash data on mobile platforms for post-mortem analysis. |
 
 Upstream OTel SDKs are technically [Compatible] with Elastic and can send data through the same ingestion paths, but Elastic does not provide official support or troubleshooting assistance for them. Refer to the [SDK compatibility table](sdks.md) for version-level details.
 
 :::{important}
-EDOT SDKs are designed to export telemetry through the [EDOT Collector](elastic-agent://reference/edot-collector/index.md) or the [{{motlp}}](/reference/managed-inputs/managed-otlp-endpoint.md). Using EDOT SDKs directly with {{product.apm-server}}'s OpenTelemetry intake is not supported — attribute mapping, enrichment, and processing pipelines are not guaranteed on that path.
+Elastic OTel SDKs are designed to export telemetry through the [{{agent}}](elastic-agent://reference/edot-collector/index.md) or the [{{motlp}}](/reference/managed-inputs/managed-otlp-endpoint.md). Using Elastic OTel SDKs directly with {{product.apm-server}}'s OpenTelemetry intake is not supported — attribute mapping, enrichment, and processing pipelines are not guaranteed on that path.
 :::
 
 ## Kubernetes Operator
 
-EDOT does not ship its own Kubernetes operator. Instead, EDOT deployments on Kubernetes rely on the upstream [OpenTelemetry Operator](https://opentelemetry.io/docs/platforms/kubernetes/operator/), which manages Collector deployments and auto-instrumentation of workloads through Kubernetes custom resource definitions (CRDs).
+{{edot}} does not ship its own Kubernetes operator. Instead, {{edot}} deployments on Kubernetes rely on the upstream [OpenTelemetry Operator](https://opentelemetry.io/docs/platforms/kubernetes/operator/), which manages Collector deployments and auto-instrumentation of workloads through Kubernetes custom resource definitions (CRDs).
 
-In an EDOT-based Kubernetes setup, the operator's `OpenTelemetryCollector` CRD deploys EDOT Collector images as DaemonSets, Deployments, or StatefulSets, and the `Instrumentation` CRD is configured to inject EDOT SDK images (for example, `docker.elastic.co/observability/elastic-otel-javaagent`) instead of the default upstream images. The operator handles the mechanics of admission webhooks and init container injection, while EDOT provides the container images and configurations that the operator deploys.
+In an {{edot}}-based Kubernetes setup, the operator's `OpenTelemetryCollector` CRD deploys {{agent}} images as DaemonSets, Deployments, or StatefulSets, and the `Instrumentation` CRD is configured to inject Elastic OTel SDK images (for example, `docker.elastic.co/observability/elastic-otel-javaagent`) instead of the default upstream images. The operator handles the mechanics of admission webhooks and init container injection, while {{edot}} provides the container images and configurations that the operator deploys.
 
-This creates a dual support model. The operator itself is an upstream community project and receives community support. The EDOT Collector and SDK images that the operator deploys are covered by Elastic support under the same terms as their standalone counterparts. When filing issues, distinguish between operator behavior (community support) and EDOT component behavior (Elastic support).
+This creates a dual support model. The operator itself is an upstream community project and receives community support. The {{agent}} and SDK images that the operator deploys are covered by Elastic support under the same terms as their standalone counterparts. When filing issues, distinguish between operator behavior (community support) and {{edot}} component behavior (Elastic support).
 
 On platforms that provide their own OpenTelemetry distributions, such as [Red Hat OpenShift](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/red_hat_build_of_opentelemetry/index) or [AWS Lambda (ADOT)](https://aws-otel.github.io/docs/getting-started/lambda), those platform-native distributions can be used [at the edge](/reference/architecture/index.md#understanding-edge-deployment) instead. Elastic does not provide support for third-party distributions, but they remain [Compatible] as long as they export data over OTLP. Refer to the [Kubernetes architecture page](/reference/architecture/k8s.md) and the [Kubernetes use case guide](docs-content://solutions/observability/get-started/opentelemetry/use-cases/kubernetes/index.md) for deployment details.
 
-## EDOT Cloud Forwarders
+## {{edot-cf}}
 
-The [EDOT Cloud Forwarders](/reference/edot-cloud-forwarder/index.md) are Elastic-specific components with no upstream equivalent. They package the EDOT Collector as a cloud function — AWS Lambda, Azure Function, or GCP Cloud Run — to collect telemetry from cloud provider services such as S3, CloudWatch, Blob Storage, Event Hub, GCS, and GCP Operations, and forward it to the [{{motlp}}](/reference/managed-inputs/managed-otlp-endpoint.md).
+The [{{edot-cf}}](/reference/edot-cloud-forwarder/index.md) are Elastic-specific components with no upstream equivalent. They package the {{agent}} as a cloud function — AWS Lambda, Azure Function, or GCP Cloud Run — to collect telemetry from cloud provider services such as S3, CloudWatch, Blob Storage, Event Hub, GCS, and GCP Operations, and forward it to the [{{motlp}}](/reference/managed-inputs/managed-otlp-endpoint.md).
 
-Because there is no upstream counterpart, the EDOT-versus-upstream comparison does not apply to Cloud Forwarders. Refer to the [EDOT Cloud Forwarder documentation](/reference/edot-cloud-forwarder/index.md) for setup guides and supported cloud services.
+Because there is no upstream counterpart, the {{edot}}-versus-upstream comparison does not apply to Cloud Forwarders. Refer to the [{{edot-cf}} documentation](/reference/edot-cloud-forwarder/index.md) for setup guides and supported cloud services.
 
 ## OTel Demo
 
 The upstream [OpenTelemetry Demo](https://opentelemetry.io/docs/demo/) is a multi-service reference application instrumented in over a dozen languages. It demonstrates distributed tracing, metrics collection, and log correlation across a realistic microservices architecture, using Jaeger and Prometheus as backends.
 
-Elastic maintains a [fork of the demo](https://github.com/elastic/opentelemetry-demo) that replaces these default backends with an {{stack}} deployment. The fork ships EDOT Collector configurations for both Kubernetes and host scenarios, allowing teams to see how EDOT components work together in a near-production environment before rolling them out.
+Elastic maintains a [fork of the demo](https://github.com/elastic/opentelemetry-demo) that replaces these default backends with an {{stack}} deployment. The fork ships {{agent}} configurations for both Kubernetes and host scenarios, allowing teams to see how {{edot}} components work together in a near-production environment before rolling them out.
 
-The EDOT demo is a learning and showcase tool, not a production artifact. Elastic does not provide support for the demo application itself, but the EDOT components running within it follow the same support terms as their standalone releases.
+The {{edot}} demo is a learning and showcase tool, not a production artifact. Elastic does not provide support for the demo application itself, but the {{edot}} components running within it follow the same support terms as their standalone releases.
 
 [Incompatible]: nomenclature.md
 [Compatible]: nomenclature.md

--- a/docs/reference/compatibility/edot-vs-upstream.md
+++ b/docs/reference/compatibility/edot-vs-upstream.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: "{{edot}} compared to upstream"
-description: How {{edot}} compare to upstream OpenTelemetry components, including Collector, SDKs, Kubernetes Operator, and more.
+description: How {{edot}} compares to upstream OpenTelemetry components, including Collector, SDKs, Kubernetes Operator, and more.
 applies_to:
   stack:
   serverless:

--- a/docs/reference/compatibility/features.md
+++ b/docs/reference/compatibility/features.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Features
-description: Overview of Elastic features available with EDOT.
+description: Overview of Elastic features available with {{edot}}.
 applies_to:
   stack:
   serverless:
@@ -12,13 +12,13 @@ products:
   - id: edot-sdk
 ---
 
-# Elastic features available with EDOT
+# Elastic features available with {{edot}}
 
-The following table shows Elastic features and their level of support and compatibility with Elastic Distributions of OpenTelemetry (EDOT). Refer to the [SDKs Overview](/reference/edot-sdks/index.md) for SDK-specific features.
+The following table shows Elastic features and their level of support and compatibility with {{edot}}. Refer to the [SDKs Overview](/reference/edot-sdks/index.md) for SDK-specific features.
 
 | Feature                                                     | Compatibility    | Support level    |
 | :-----------------------------------------------------------| :--------------- | :--------------- |
-| **APM**                                                     | [Compatible]     | [Supported]      |
+| **{{product.apm}}**                                         | [Compatible]     | [Supported]      |
 | [Service Maps]                                              | [Compatible]     | [Supported]      |
 | [Distributed Tracing]                                       | [Compatible]     | [Supported]      |
 | [Head-based Sampling (HBS)]                                 | [Compatible]     | [Supported]      |

--- a/docs/reference/compatibility/index.md
+++ b/docs/reference/compatibility/index.md
@@ -12,14 +12,14 @@ products:
   - id: edot-sdk
 ---
 
-# EDOT compatibility and support
+# {{edot}} compatibility and support
 
 The following pages describe the compatibility and support levels for different OpenTelemetry Distributions.
 
 - [Features](features.md)
 - [Collectors](collectors.md)
 - [SDKs](sdks.md)
-- [EDOT compared to upstream OpenTelemetry](edot-vs-upstream.md)
+- [{{edot}} compared to upstream](edot-vs-upstream.md)
 - [Limitations](limitations.md)
 - [Nomenclature](nomenclature.md)
 - [Data streams comparison](data-streams.md)

--- a/docs/reference/compatibility/limitations.md
+++ b/docs/reference/compatibility/limitations.md
@@ -20,7 +20,7 @@ While {{edot}} and OTel-native data collection already covers most of the core O
 
 ## When to use the classic {{stack}} ingestion components instead of {{edot}}
 
-{{edot}} already supports most core observability use cases, but in some scenarios, you may prefer to use classic Elastic ingestion components, such as {{agent}}, {{product.apm-agent}} or {{product.apm-server}}:
+{{edot}} already supports most core observability use cases, but in some scenarios, you may prefer to use classic Elastic ingestion components, such as {{agent}} ({{product.fleet}}-managed), {{product.apm-agent}} or {{product.apm-server}}:
 
 * **Real user monitoring (RUM):** RUM ingestion and visualizations are not yet available for OTel-native data.
 * **Universal profiling:** This capability is currently only supported in the classic stack.

--- a/docs/reference/compatibility/limitations.md
+++ b/docs/reference/compatibility/limitations.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Limitations
-description: Limitations of Elastic Distributions of OpenTelemetry (EDOT) compared to classic Elastic data collection mechanisms.
+description: Limitations of {{edot}} compared to classic Elastic data collection mechanisms.
 applies_to:
   stack:
   serverless:
@@ -12,34 +12,34 @@ products:
    - id: edot-sdk
 ---
 
-# Limitations of Elastic Distributions of OpenTelemetry (EDOT)
+# Limitations of {{edot}}
 
-The Elastic Distributions of OpenTelemetry (EDOT) come with a new way of ingesting data in OTel-native way and format. Elastic is actively improving OTel-native data support within Elastic solutions, contributing popular Elastic features to the contrib OpenTelemetry projects and aligning concepts with OpenTelemetry.
+{{edot}} come with a new way of ingesting data in OTel-native way and format. Elastic is actively improving OTel-native data support within Elastic solutions, contributing popular Elastic features to the contrib OpenTelemetry projects and aligning concepts with OpenTelemetry.
 
-While EDOT and OTel-native data collection already covers most of the core Observability use cases, the following limitations apply compared to data collection with classic Elastic data ingestion components.
+While {{edot}} and OTel-native data collection already covers most of the core Observability use cases, the following limitations apply compared to data collection with classic Elastic data ingestion components.
 
-## When to use the classic Elastic Stack ingestion components instead of EDOT
+## When to use the classic {{stack}} ingestion components instead of {{edot}}
 
-EDOT already supports most core observability use cases, but in some scenarios, you may prefer to use classic Elastic ingestion components, such as Elastic Agent, Elastic APM Agent or APM Server:
+{{edot}} already supports most core observability use cases, but in some scenarios, you may prefer to use classic Elastic ingestion components, such as {{agent}}, {{product.apm-agent}} or {{product.apm-server}}:
 
 * **Real user monitoring (RUM):** RUM ingestion and visualizations are not yet available for OTel-native data.
 * **Universal profiling:** This capability is currently only supported in the classic stack.
 * **Existing integrations and dashboards:** Many prebuilt Elastic integrations and dashboards are designed for ECS-formatted data and may not work as expected with the OpenTelemetry semantic conventions without customization.
 * **Ingest pipelines for structuring logs:** {{es}} ingest pipelines cannot directly parse OTel-native data with dotted field names without preprocessing. See [Centralized parsing and processing of data](#centralized-parsing-and-processing-of-data) for workarounds.
 * **Tail-based sampling (TBS):**  
-If you need the full tail-based sampling capabilities of APM Server, use APM Server with an Elasticsearch output. EDOT does not provide managed TBS. You can run TBS in a self-managed EDOT Collector or any contrib OTel Collector and ingest the sampled traces into Elastic with some caveats - refer to [Tail-based sampling limitations](#tail-based-sampling-tbs) for more information.
+If you need the full tail-based sampling capabilities of APM Server, use APM Server with an {{es}} output. {{edot}} does not provide managed TBS. You can run TBS in a self-managed {{agent}} or any contrib OTel Collector and ingest the sampled traces into Elastic with some caveats - refer to [Tail-based sampling limitations](#tail-based-sampling-tbs) for more information.
 
-Refer to [EDOT data streams compared to classic APM](../compatibility/data-streams.md) for an overview of how these ingestion paths differ.
+Refer to [{{edot}} data streams compared to classic {{product.apm}}](../compatibility/data-streams.md) for an overview of how these ingestion paths differ.
 
 ## Centralized parsing and processing of data
 
-With OTel-native ingestion of data, for example through the EDOT Collector or the [Managed OTLP endpoint](/reference/managed-inputs/managed-otlp-endpoint.md), [{{es}} Ingest Pipelines](docs-content://manage-data/ingest/transform-enrich/ingest-pipelines.md) are not supported.
+With OTel-native ingestion of data, for example through the {{agent}} or the [Managed OTLP endpoint](/reference/managed-inputs/managed-otlp-endpoint.md), [{{es}} Ingest Pipelines](docs-content://manage-data/ingest/transform-enrich/ingest-pipelines.md) are not supported.
 
 The OTel-native data format in {{es}} contains dotted fields. Ingest Pipeline processors can't access fields that have a dot in their name without having previously transformed the dotted field into an object using the [`Dot expander processor`](elasticsearch://reference/enrich-processor/dot-expand-processor.md).
 
 To process your OTel data, for example to parse logs data, route data to data streams, and so on, use [Collector processors](https://opentelemetry.io/docs/collector/configuration/#processors), [`filelogreceiver` operators](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/stanza/docs/operators/README.md#what-operators-are-available) and other OTel-native processing capabilities.
 
-Refer to [these examples](elastic-agent://reference/edot-collector/config/configure-logs-collection.md) on how to process log data with the (EDOT) OTel Collector.
+Refer to [these examples](elastic-agent://reference/edot-collector/config/configure-logs-collection.md) on how to process log data with {{agent}}.
 
 ## Infrastructure and host metrics
 
@@ -47,14 +47,14 @@ Due to limitations and gaps in data collection with the contrib OTel `hostmetric
 
 | Limitation                                      | Explanation                                                                                                                                                                                                                     |
 |------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Host network panels do not display data in some Elastic Observability UIs. | Due to an contrib limitation, `host.network.*` metrics are not available from OpenTelemetry.                                                                                                                                   |
+| Host network panels do not display data in some {{product.observability}} UIs. | Due to an contrib limitation, `host.network.*` metrics are not available from OpenTelemetry.                                                                                                                                   |
 | Process state is unavailable in OpenTelemetry host metrics. | The `process.state` metric is not present and is assigned a dummy value of "Unknown" in the State column of the host processes table.                                                                                           |
 | Host OS version and operating system may show as "N/A". | Although the {{es}} exporter processes resource attributes, it may not populate these values.                                                                                                                            |
 | Normalized Load data is missing unless the CPU scraper is enabled. | The `system.load.cores` metric is required for the Normalized Load column in the Hosts table and the Normalized Load visualization in the host detailed view.                                                                    |
 | MacOS collectors do not support CPU and disk metrics. | The `hostmetrics receiver` does not collect these metrics on macOS, leaving related fields empty.                    |
 | Permission issues may cause error logs for process metrics | The `hostmetrics receiver` logs errors if it cannot access certain process information due to insufficient permissions. |
 
-When collecting host metrics through a distribution of the OTel Collector other than EDOT, make sure to turn on required metrics that are otherwise turned off by default. Use the EDOT Collector [sample config](elastic-agent://reference/edot-collector/config/default-config-standalone.md) for the `hostmetrics` receiver as reference.
+When collecting host metrics through a distribution of the OTel Collector other than {{edot}}, make sure to turn on required metrics that are otherwise turned off by default. Use the {{agent}} [sample config](elastic-agent://reference/edot-collector/config/default-config-standalone.md) for the `hostmetrics` receiver as reference.
 
 ## Metrics data ingestion
 
@@ -70,7 +70,7 @@ Exemplars are discarded when ingesting metrics. Support for exemplars is planned
 
 ## Limitations on managed Kubernetes environments
 
-Due to limitations with permissions on managed Kubernetes environments, such as GKE Autopilot or AWS Fargate, the default configurations and onboarding flows for EDOT don't fully work in those environments. This might result in decreased collection of data and certain observability views not showing that data.
+Due to limitations with permissions on managed Kubernetes environments, such as GKE Autopilot or AWS Fargate, the default configurations and onboarding flows for {{edot}} don't fully work in those environments. This might result in decreased collection of data and certain observability views not showing that data.
 
 ## Limitations with APM
 
@@ -88,9 +88,9 @@ Runtime metrics can be ingested and used to create custom dashboards. As a tempo
 
 ## Tail-based sampling (TBS)
 
-If you need the full tail-based sampling capabilities of APM Server, use APM Server with an Elasticsearch output. EDOT does not provide a managed TBS service.
+If you need the full tail-based sampling capabilities of APM Server, use APM Server with an {{es}} output. {{edot}} does not provide a managed TBS service.
 
-You can run tail-based sampling in a self-managed EDOT Collector or any contrib OTel Collector and ingest the sampled traces into Elastic, with these caveats:
+You can run tail-based sampling in a self-managed {{agent}} or any contrib OTel Collector and ingest the sampled traces into Elastic, with these caveats:
 
 * **Metric accuracy:** Counts and rate metrics reflect sampled data, not total volumes. The Elastic APM backend cannot extrapolate totals because the `tailsamplingprocessor` does not send sampling probability metadata.
 * **Service map coverage:** Some edges between services may be missing.

--- a/docs/reference/compatibility/nomenclature.md
+++ b/docs/reference/compatibility/nomenclature.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Nomenclature
-description: Explanation of compatibility and support states (Incompatible, Compatible, Supported) for EDOT components.
+description: Explanation of compatibility and support states (Incompatible, Compatible, Supported) for {{edot}} components.
 applies_to:
   stack:
   serverless:
@@ -12,11 +12,11 @@ products:
   - id: edot-sdk
 ---
 
-# EDOT compatibility and support nomenclature
+# {{edot}} compatibility and support nomenclature
 
 OpenTelemetry (OTel) is a modular, extensible framework designed to integrate with a wide range of technologies. Its architecture enables interoperability across many components, extensions, and tools, giving users flexibility to shape their observability pipelines.
 
-Elastic Distributions of OpenTelemetry (EDOT) are built from contrib OTel components and are technically compatible with a broad set of community components. Users can also send data to Elastic using other contrib OTel components or distributions like the contrib Collector and OTel SDKs, which are technically compatible with Elastic’s ingestion APIs.
+{{edot}} are built from contrib OTel components and are technically compatible with a broad set of community components. Users can also send data to Elastic using other contrib OTel components or distributions like the contrib Collector and OTel SDKs, which are technically compatible with Elastic’s ingestion APIs.
 
 *Supported through Elastic* refers to components and configurations that Elastic has explicitly tested, validated, and committed to maintaining under our [Support Policies](https://www.elastic.co/support). This includes regular updates, issue triaging, and guidance from Elastic’s support and engineering teams. Components outside of this supported set may still work, but Elastic does not provide guaranteed support or troubleshooting assistance for them.
 
@@ -31,7 +31,7 @@ In the following sections we differentiate the following compatibility and suppo
 
 ## Categorization of Collector components
 
-The EDOT Collector includes two types of components with different compatibility and support scope: Core and Extended.
+{{agent}} includes two types of components with different compatibility and support scope: Core and Extended.
 
 ### Core components
 
@@ -43,7 +43,7 @@ Extended components are a curated set of optional components that enhance functi
 
 ### Breaking changes
 
-Because the EDOT Collector is built on contrib OpenTelemetry, breaking contrib changes might impact both Extended and Core components. For example, breaking changes in semantic conventions or configuration options. Elastic highlights and manages these through docs and support channels.
+Because {{agent}} is built on contrib OpenTelemetry, breaking contrib changes might impact both Extended and Core components. For example, breaking changes in semantic conventions or configuration options. Elastic highlights and manages these through docs and support channels.
 
 :::{tip}
 For the best support experience, rely on Core components and use Extended Components only when required.

--- a/docs/reference/compatibility/sdks.md
+++ b/docs/reference/compatibility/sdks.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: SDK Distributions
-description: Compatibility and support information for EDOT SDK versions with EDOT Collector versions.
+description: Compatibility and support information for Elastic OTel SDK versions with {{agent}} versions.
 applies_to:
   stack:
   serverless:
@@ -11,44 +11,44 @@ products:
   - id: edot-sdk
 ---
 
-# EDOT compatibility and support for OTel SDKs
+# {{edot}} compatibility and support for OTel SDKs
 
-The following table provides an overview of compatibility and support of EDOT SDKs with EDOT Collector versions:
+The following table provides an overview of compatibility and support of Elastic OTel SDKs with {{agent}} versions:
 
-| EDOT Collector version        | **< 8.16**         | **8.16 to 8.19**    | **9.x**            |
+| {{agent}} version        | **< 8.16**         | **8.16 to 8.19**    | **9.x**            |
 | :----------------------- | :----------------- | :------------------ | :----------------- |
 | **Compatibility**        | [Incompatible]     | [Compatible]        | [Compatible]       |
 | **Level of support**     | [Not supported]    | [Not supported]     | [Supported]        |
 
-This applies to all EDOT SDKs:
+This applies to all Elastic OTel SDKs:
 
-- EDOT .NET
-- EDOT Java
-- EDOT Node.js
-- EDOT PHP
-- EDOT Python
-- EDOT Android
-- EDOT iOS
+- Elastic OTel .NET
+- Elastic OTel Java
+- Elastic OTel Node.js
+- Elastic OTel PHP
+- Elastic OTel Python
+- Elastic OTel Android
+- Elastic OTel iOS
 
-Refer to the [EDOT Collector compatibility table](collectors.md) for compatibility with Elastic Stack versions.
+Refer to the [{{agent}} compatibility table](collectors.md) for compatibility with {{stack}} versions.
 
-For the best experience, export data from EDOT SDKs using the [EDOT Collector](elastic-agent://reference/edot-collector/index.md).
+For the best experience, export data from Elastic OTel SDKs using the [{{agent}}](elastic-agent://reference/edot-collector/index.md).
 
 :::{note}
-Ingesting data from EDOT SDKs through EDOT Collector into Elastic Stack versions 8.18 or higher is supported ([Supported]).
+Ingesting data from Elastic OTel SDKs through {{agent}} into {{stack}} versions 8.18 or higher is supported ([Supported]).
 :::
 
-## Support matrix for EDOT SDK ingestion
+## Support matrix for Elastic OTel SDK ingestion
 
 | Ingestion path | Supported | Notes |
 |----------------|-----------|-------|
-| **EDOT Collector (Gateway)** | Yes | Fully tested and recommended. |
+| **{{agent}} (Gateway)** | Yes | Fully tested and recommended. |
 | **{{motlp}}** | Yes | Fully supported for {{serverless-full}} and {{ech}}. |
 | **{{product.apm-server}} OTel intake** | Not supported | Telemetry might ingest but mapping, enrichment, and troubleshooting are not guaranteed. |
 
-## Supported technologies per EDOT SDK
+## Supported technologies per Elastic OTel SDK
 
-For compatibility of language-specific technologies check out the following pages for corresponding EDOT SDKs:
+For compatibility of language-specific technologies check out the following pages for corresponding Elastic OTel SDKs:
 
 - [Supported Technologies - .NET](elastic-otel-dotnet://reference/edot-dotnet/supported-technologies.md)
 - [Supported Technologies - Java](elastic-otel-java://reference/edot-java/supported-technologies.md)

--- a/docs/reference/compatibility/sdks.md
+++ b/docs/reference/compatibility/sdks.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: SDK Distributions
-description: Compatibility and support information for Elastic OTel SDK versions with {{agent}} versions.
+description: Compatibility and support information for EDOT SDK versions with {{agent}} versions.
 applies_to:
   stack:
   serverless:
@@ -13,32 +13,32 @@ products:
 
 # {{edot}} compatibility and support for OTel SDKs
 
-The following table provides an overview of compatibility and support of Elastic OTel SDKs with {{agent}} versions:
+The following table provides an overview of compatibility and support of EDOT SDKs with {{agent}} versions:
 
 | {{agent}} version        | **< 8.16**         | **8.16 to 8.19**    | **9.x**            |
 | :----------------------- | :----------------- | :------------------ | :----------------- |
 | **Compatibility**        | [Incompatible]     | [Compatible]        | [Compatible]       |
 | **Level of support**     | [Not supported]    | [Not supported]     | [Supported]        |
 
-This applies to all Elastic OTel SDKs:
+This applies to all EDOT SDKs:
 
-- Elastic OTel .NET
-- Elastic OTel Java
-- Elastic OTel Node.js
-- Elastic OTel PHP
-- Elastic OTel Python
-- Elastic OTel Android
-- Elastic OTel iOS
+- EDOT .NET
+- EDOT Java
+- EDOT Node.js
+- EDOT PHP
+- EDOT Python
+- EDOT Android
+- EDOT iOS
 
 Refer to the [{{agent}} compatibility table](collectors.md) for compatibility with {{stack}} versions.
 
-For the best experience, export data from Elastic OTel SDKs using the [{{agent}}](elastic-agent://reference/edot-collector/index.md).
+For the best experience, export data from EDOT SDKs using the [{{agent}}](elastic-agent://reference/edot-collector/index.md).
 
 :::{note}
-Ingesting data from Elastic OTel SDKs through {{agent}} into {{stack}} versions 8.18 or higher is supported ([Supported]).
+Ingesting data from EDOT SDKs through {{agent}} into {{stack}} versions 8.18 or higher is supported ([Supported]).
 :::
 
-## Support matrix for Elastic OTel SDK ingestion
+## Support matrix for EDOT SDK ingestion
 
 | Ingestion path | Supported | Notes |
 |----------------|-----------|-------|
@@ -46,9 +46,9 @@ Ingesting data from Elastic OTel SDKs through {{agent}} into {{stack}} versions 
 | **{{motlp}}** | Yes | Fully supported for {{serverless-full}} and {{ech}}. |
 | **{{product.apm-server}} OTel intake** | Not supported | Telemetry might ingest but mapping, enrichment, and troubleshooting are not guaranteed. |
 
-## Supported technologies per Elastic OTel SDK
+## Supported technologies per EDOT SDK
 
-For compatibility of language-specific technologies check out the following pages for corresponding Elastic OTel SDKs:
+For compatibility of language-specific technologies check out the following pages for corresponding EDOT SDKs:
 
 - [Supported Technologies - .NET](elastic-otel-dotnet://reference/edot-dotnet/supported-technologies.md)
 - [Supported Technologies - Java](elastic-otel-java://reference/edot-java/supported-technologies.md)

--- a/docs/reference/data-streams.md
+++ b/docs/reference/data-streams.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Data streams
-description: Learn how EDOT stores OpenTelemetry signals in Elasticsearch. Understand OTel-native and ECS-compatible data streams, exporter behavior, storage engines, and how to configure data retention.
+description: Learn how {{edot}} stores OpenTelemetry signals in Elasticsearch. Understand OTel-native and ECS-compatible data streams, exporter behavior, storage engines, and how to configure data retention.
 applies_to:
   stack:
   serverless:
@@ -11,28 +11,28 @@ products:
   - id: edot-collector
 ---
 
-# EDOT data streams
+# {{edot}} data streams
 
 {{edot}} writes telemetry data to two types of data stream schemas in {{es}}:
 
 - OTel-native data streams (default)
 - ECS-compatible data streams (for backwards compatibility with {{product.apm}})
 
-This page provides a practical reference for which data streams EDOT uses, exporter behavior, storage engines, and how to configure data retention. For a detailed comparison of OTel data streams with classic {{product.apm}} and ECS-based integrations, refer to [OTel data streams compared to classic {{product.apm}}](./compatibility/data-streams.md).
+This page provides a practical reference for which data streams {{edot}} uses, exporter behavior, storage engines, and how to configure data retention. For a detailed comparison of OTel data streams with classic {{product.apm}} and ECS-based integrations, refer to [OTel data streams compared to classic {{product.apm}}](./compatibility/data-streams.md).
 
 To learn how to route OpenTelemetry (OTel) signals to custom data streams, refer to [Data stream routing](docs-content://solutions/observability/apm/opentelemetry/data-stream-routing.md).
 
 ## Exporter behavior
 
-EDOT uses the `otel` exporter by default, which sends data to OTel-native data streams. For backwards compatibility with legacy {{product.apm}} data formats, EDOT can also use the `ecs` exporter, which sends data to ECS-compatible data streams.
+{{edot}} uses the `otel` exporter by default, which sends data to OTel-native data streams. For backwards compatibility with legacy {{product.apm}} data formats, {{edot}} can also use the `ecs` exporter, which sends data to ECS-compatible data streams.
 
 ## Data streams used by a local deployment
 
-When EDOT runs as a [local gateway or Collector](/reference/architecture/index.md), it writes telemetry data to different data streams depending on the exporter configuration and data source:
+When {{edot}} runs as a [local gateway or Collector](/reference/architecture/index.md), it writes telemetry data to different data streams depending on the exporter configuration and data source:
 
 ### OTel-native mode
 
-This is the default mode. When ingesting standard OTel signals, EDOT writes to:
+This is the default mode. When ingesting standard OTel signals, {{edot}} writes to:
 
 | Signal | Data stream |
 |--------|-------------|
@@ -45,13 +45,13 @@ These streams follow OTel naming conventions and field structures.
 
 ### ECS-compatible data streams
 
-When ingesting data from {{product.apm}} agents using the `elasticapmintake` receiver, EDOT automatically routes data to ECS-compatible data streams. The `elasticapmintake` receiver determines the destination data stream and internally uses ECS-compatible formatting for compatibility with legacy {{product.apm-server}} behavior. 
+When ingesting data from {{product.apm}} agents using the `elasticapmintake` receiver, {{edot}} automatically routes data to ECS-compatible data streams. The `elasticapmintake` receiver determines the destination data stream and internally uses ECS-compatible formatting for compatibility with legacy {{product.apm-server}} behavior. 
 
 :::{note}
 The `elasticapmintake` receiver is intended for migration use cases from classic {{product.apm}} agents. For new deployments, we recommend using OTel SDKs with the default OTel-native data streams.
 :::
 
-When the `ecs` exporter is explicitly enabled, EDOT writes to:
+When the `ecs` exporter is explicitly enabled, {{edot}} writes to:
 
 - `traces-apm-*`
 - `metrics-apm.internal-*`
@@ -64,12 +64,12 @@ These match legacy {{product.apm-server}} behavior.
 
 ## Managed OTLP Endpoint
 
-The {{motlp}} follows the same stream selection logic as local EDOT deployments:
+The {{motlp}} follows the same stream selection logic as local {{edot}} deployments:
 
 - OTel-native streams for standard OTel telemetry  
 - ECS-compatible streams for {{product.apm}}-formatted events  
 
-The main difference is that {{motlp}} is a managed cloud service that handles ingestion and storage, whereas local EDOT deployments require you to manage the Collector infrastructure yourself. Ingest and storage behavior remain consistent between both approaches.
+The main difference is that {{motlp}} is a managed cloud service that handles ingestion and storage, whereas local {{edot}} deployments require you to manage the Collector infrastructure yourself. Ingest and storage behavior remain consistent between both approaches.
 
 To customize which data streams your telemetry is routed to, you can use [data stream routing](docs-content://solutions/observability/apm/opentelemetry/data-stream-routing.md) with `data_stream.dataset` and `data_stream.namespace` attributes.
 
@@ -83,16 +83,16 @@ You may notice fields like:
 These are not true duplicates. Here's why:
 
 - OTel defines attributes at multiple levels (for example: resource, span).
-- EDOT stores resource attributes under `resource.attributes.*`, according to OTel specifications.
+- {{edot}} stores resource attributes under `resource.attributes.*`, according to OTel specifications.
 - {{kib}} dashboards and {{product.apm}} UI rely on ECS-style top-level fields like `service.name`.
 
 For more information about how resource attributes are mapped to ECS fields and stored, refer to [Attributes and labels](docs-content://solutions/observability/apm/opentelemetry/attributes.md).
 
-EDOT uses two mechanisms to bridge these models:
+{{edot}} uses two mechanisms to bridge these models:
 
-1. **Passthrough fields**: When fields are propagated from `resource.attributes` to top level (also for `scope.attributes` and `attributes`), EDOT uses passthrough fields with no storage overhead.
+1. **Passthrough fields**: When fields are propagated from `resource.attributes` to top level (also for `scope.attributes` and `attributes`), {{edot}} uses passthrough fields with no storage overhead.
 
-2. **Field copying**: EDOT performs some copying for specific fields for enrichment and compatibility purposes. This copying is separate from the passthrough mechanism. For example, conditionally copying `span.id` to `transaction.id`.
+2. **Field copying**: {{edot}} performs some copying for specific fields for enrichment and compatibility purposes. This copying is separate from the passthrough mechanism. For example, conditionally copying `span.id` to `transaction.id`.
 
 These mechanisms ensure that:
 
@@ -104,21 +104,21 @@ This duplication is intentional.
 
 ## Storage engines
 
-The storage engine used by EDOT depends on which data stream the data is sent to. Different data streams use different index templates, and the index templates determine which storage engine is used.
+The storage engine used by {{edot}} depends on which data stream the data is sent to. Different data streams use different index templates, and the index templates determine which storage engine is used.
 
 For example:
-- When EDOT sends to OTel-native data streams (using the `otel` exporter), the data uses the storage engines configured for those data streams.
-- When EDOT sends to ECS-compatible data streams (using `elasticapmintake` or the `ecs` exporter), the data uses the storage engines configured for those data streams.
+- When {{edot}} sends to OTel-native data streams (using the `otel` exporter), the data uses the storage engines configured for those data streams.
+- When {{edot}} sends to ECS-compatible data streams (using `elasticapmintake` or the `ecs` exporter), the data uses the storage engines configured for those data streams.
 
-EDOT uses the same index templates and mappings as the rest of the Observability solution.
+{{edot}} uses the same index templates and mappings as the rest of the Observability solution.
 
 ## Data stream lifecycle and retention
 
-EDOT data streams have no default retention period. Backing indices roll over when they reach 50 GB or 30 days old, but data is not automatically deleted unless you configure a delete phase.
+{{edot}} data streams have no default retention period. Backing indices roll over when they reach 50 GB or 30 days old, but data is not automatically deleted unless you configure a delete phase.
 
 ### {{ech}} and self-managed deployments
 
-OTel-native EDOT data streams use the built-in ILM policies `logs`, `metrics`, and `traces@lifecycle`, as set by the `logs@settings`, `metrics@tsdb-settings`, and `traces@settings` component templates that the OTel index templates compose in {{es}}. To customize retention without modifying those managed policies, create a `@custom` component template for the relevant signal type:
+OTel-native {{edot}} data streams use the built-in ILM policies `logs`, `metrics`, and `traces@lifecycle`, as set by the `logs@settings`, `metrics@tsdb-settings`, and `traces@settings` component templates that the OTel index templates compose in {{es}}. To customize retention without modifying those managed policies, create a `@custom` component template for the relevant signal type:
 
 | Signal | Component template |
 |--------|--------------------|

--- a/docs/reference/edot-cloud-forwarder/gcp/index.md
+++ b/docs/reference/edot-cloud-forwarder/gcp/index.md
@@ -1,6 +1,6 @@
 ---
-navigation_title: EDOT Cloud Forwarder for GCP
-description: Set up the EDOT Cloud Forwarder for GCP to bring your GCP logs to Elastic Observability.
+navigation_title: Elastic Cloud Forwarder for GCP
+description: Set up {{edot-cf}} for GCP to bring your GCP logs to Elastic Observability.
 applies_to:
   serverless:
     observability: preview
@@ -15,7 +15,7 @@ products:
   - id: edot-cf
 ---
 
-# EDOT Cloud Forwarder for GCP
+# {{edot-cf}} for GCP
 
 {{edot-cf}} (ECF) for GCP is a managed data pipeline that sends your Google Cloud logs to {{product.observability}}. It uses Google Cloud Run and Pub/Sub under the hood to receive log events, process them with an OpenTelemetry Collector, and forward them to the {{motlp}}.
 
@@ -23,7 +23,7 @@ products:
 
 The architecture for the {{edot-cf}} GCP is as follows:
 
-![EDOT Cloud Forwarder GCP overview](../../images/edot-cloud-forwarder-gcp-overview.png)
+![{{edot-cf}} GCP overview](../../images/edot-cloud-forwarder-gcp-overview.png)
 
 At a high level, the deployment consists of:
 
@@ -283,7 +283,7 @@ The current retry logic treats all failures the same way, whether they're tempor
 ECF reads each log file fully into memory before forwarding it. As a result, peak memory usage grows with both file size and the number of concurrent requests. Our recommendations (1 vCPU, 512MiB, up to 10 concurrent requests) are based on internal tests with files up to about 8MB (~6,000 logs) each. If you send much larger files or significantly more logs per request, you might need to lower per‑instance concurrency, allocate more memory per instance, or do both to avoid out‑of‑memory issues.
 :::
 
-## Remove EDOT CF
+## Remove {{edot-cf}}
 
 To remove {{edot-cf}} for GCP, destroy the resources created by Terraform by running this command:
 

--- a/docs/reference/edot-cloud-forwarder/index.md
+++ b/docs/reference/edot-cloud-forwarder/index.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Elastic Cloud Forwarder
-description: Introduction to {{edot-cf}}, the {{edot}} Collector for Cloud providers. Send your telemetry data to Elastic Stack from AWS, GCP, and Azure.
+description: Introduction to {{edot-cf}}, a cloud-native telemetry forwarder for AWS, GCP, and Azure.
 applies_to:
   serverless:
     observability: preview

--- a/docs/reference/edot-cloud-forwarder/index.md
+++ b/docs/reference/edot-cloud-forwarder/index.md
@@ -1,6 +1,6 @@
 ---
-navigation_title: EDOT Cloud Forwarder
-description: Introduction to the EDOT Cloud Forwarder, the Elastic Distribution of OpenTelemetry (EDOT) Collector for Cloud providers. Send your telemetry data to Elastic Stack from AWS, GCP, and Azure.
+navigation_title: Elastic Cloud Forwarder
+description: Introduction to {{edot-cf}}, the {{edot}} Collector for Cloud providers. Send your telemetry data to Elastic Stack from AWS, GCP, and Azure.
 applies_to:
   serverless:
     observability: preview
@@ -12,9 +12,9 @@ products:
   - id: edot-cf
 ---
 
-# EDOT Cloud Forwarder
+# {{edot-cf}}
 
-The Elastic Distribution of OpenTelemetry (EDOT) Cloud Forwarder provides the EDOT Collector as a function to collect and send your telemetry data to Elastic Observability from AWS, GCP, and Azure. {{edot-cf}} can collect telemetry data from object storage and cloud services.
+{{edot-cf}} provides the {{agent}} as a function to collect and send your telemetry data to Elastic Observability from AWS, GCP, and Azure. {{edot-cf}} can collect telemetry data from object storage and cloud services.
 
 {{edot-cf}} sends the data it collects directly to the [Managed OTLP endpoint](docs-content://solutions/observability/get-started/quickstart-elastic-cloud-otel-endpoint.md) of {{serverless-full}}.
 
@@ -24,9 +24,9 @@ The Elastic Distribution of OpenTelemetry (EDOT) Cloud Forwarder provides the ED
 
 | Cloud provider | Cloud service           | Availability                                   |
 |----------------|-------------------------|------------------------------------------------|
-| AWS            | S3, CloudWatch          | [EDOT Cloud Forwarder for AWS](edot-cloud-forwarder-aws://reference/edot-cf-aws/index.md)     |
-| Azure          | Blob Storage, Event Hub | [EDOT Cloud Forwarder for Azure](edot-cloud-forwarder-azure://reference/edot-cf-azure/index.md) |
-| GCP            | GCS, Operations         | [EDOT Cloud Forwarder for GCP](gcp/index.md)     |
+| AWS            | S3, CloudWatch          | [{{edot-cf}} for AWS](edot-cloud-forwarder-aws://reference/edot-cf-aws/index.md)     |
+| Azure          | Blob Storage, Event Hub | [{{edot-cf}} for Azure](edot-cloud-forwarder-azure://reference/edot-cf-azure/index.md) |
+| GCP            | GCS, Operations         | [{{edot-cf}} for GCP](gcp/index.md)     |
 
 ## Get started
 

--- a/docs/reference/edot-sdks/index.md
+++ b/docs/reference/edot-sdks/index.md
@@ -1,6 +1,6 @@
 ---
-navigation_title: Elastic OTel SDKs
-description: An overview of the features available in the Elastic OTel SDKs for various languages.
+navigation_title: EDOT SDKs
+description: An overview of the features available in the EDOT SDKs for various languages.
 applies_to:
   stack:
   serverless:
@@ -11,15 +11,15 @@ products:
   - id: edot-sdk
 ---
 
-# Elastic OTel SDKs
+# EDOT SDKs
 
-The Elastic OTel SDKs are production-ready, customized distributions of [OpenTelemetry](https://opentelemetry.io/) language SDKs, specifically optimized for seamless integration with {{product.observability}}. Elastic OTel SDKs provide a comprehensive observability solution that automatically captures distributed traces, metrics, and logs from your applications with minimal configuration.
+The EDOT SDKs are production-ready, customized distributions of [OpenTelemetry](https://opentelemetry.io/) language SDKs, specifically optimized for seamless integration with {{product.observability}}. EDOT SDKs provide a comprehensive observability solution that automatically captures distributed traces, metrics, and logs from your applications with minimal configuration.
 
-While maintaining full compatibility with the OpenTelemetry specification, Elastic OTel SDKs provide improvements and bug fixes from Elastic before they become available in contrib OpenTelemetry repositories.
+While maintaining full compatibility with the OpenTelemetry specification, EDOT SDKs provide improvements and bug fixes from Elastic before they become available in contrib OpenTelemetry repositories.
 
 ## Supported languages
 
-Elastic OTel SDKs are available for the following programming languages and platforms:
+EDOT SDKs are available for the following programming languages and platforms:
 
 * [.NET](elastic-otel-dotnet://reference/edot-dotnet/index.md)
 * [Java](elastic-otel-java://reference/edot-java/index.md)
@@ -32,9 +32,9 @@ Elastic OTel SDKs are available for the following programming languages and plat
 
 ## Feature overview
 
-This table provides an overview of the features available in the Elastic OTel SDKs across different programming languages.
+This table provides an overview of the features available in the EDOT SDKs across different programming languages.
 
-% The following table is automatically generated from the Elastic OTel SDKs feature data.
+% The following table is automatically generated from the EDOT SDKs feature data.
 % Automation is handled by /scripts/tools.py, which reads /docs/reference/edot-sdks/features.yml
 % and generates the table using a Jinja2 template.
 
@@ -77,11 +77,11 @@ This table provides an overview of the features available in the Elastic OTel SD
 
 % end:edot-features
 
-## Support for Elastic OTel SDKs
+## Support for EDOT SDKs
 
-Elastic provides technical support for Elastic OTel Language SDKs according to Elastic's [Support Policy](https://www.elastic.co/support_policy). Elastic OTel SDKs are meant to be used in combination with the [{{agent}}](elastic-agent://reference/edot-collector/index.md) or the [{{motlp}}](/reference/managed-inputs/managed-otlp-endpoint.md) to ingest data into Elastic solutions from the Elastic OTel SDKs. Other ingestion paths are not officially supported by Elastic.
+Elastic provides technical support for Elastic OTel Language SDKs according to Elastic's [Support Policy](https://www.elastic.co/support_policy). EDOT SDKs are meant to be used in combination with the [{{agent}}](elastic-agent://reference/edot-collector/index.md) or the [{{motlp}}](/reference/managed-inputs/managed-otlp-endpoint.md) to ingest data into Elastic solutions from the EDOT SDKs. Other ingestion paths are not officially supported by Elastic.
 
-Using Elastic OTel SDKs directly with {{product.apm-server}}'s OpenTelemetry intake endpoint is not supported.  
+Using EDOT SDKs directly with {{product.apm-server}}'s OpenTelemetry intake endpoint is not supported.  
 While some data might ingest, Elastic doesn't guarantee:
 
 - Correctness of attributes  
@@ -92,9 +92,9 @@ While some data might ingest, Elastic doesn't guarantee:
 If you require a supported setup, route SDK telemetry through {{agent}} or use Managed OTel intake.
 
 :::{warning}
-Avoid using Elastic OTel SDKs alongside any other {{product.apm}} agent, including Elastic {{product.apm}} agents. Running multiple agents in the same application process might lead to conflicting instrumentation, duplicate telemetry, or other unexpected behavior.
+Avoid using EDOT SDKs alongside any other {{product.apm}} agent, including Elastic {{product.apm}} agents. Running multiple agents in the same application process might lead to conflicting instrumentation, duplicate telemetry, or other unexpected behavior.
 :::
 
 ## License
 
-Elastic OTel SDKs are licensed under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0).
+EDOT SDKs are licensed under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0).

--- a/docs/reference/edot-sdks/index.md
+++ b/docs/reference/edot-sdks/index.md
@@ -79,7 +79,7 @@ This table provides an overview of the features available in the EDOT SDKs acros
 
 ## Support for EDOT SDKs
 
-Elastic provides technical support for Elastic OTel Language SDKs according to Elastic's [Support Policy](https://www.elastic.co/support_policy). EDOT SDKs are meant to be used in combination with the [{{agent}}](elastic-agent://reference/edot-collector/index.md) or the [{{motlp}}](/reference/managed-inputs/managed-otlp-endpoint.md) to ingest data into Elastic solutions from the EDOT SDKs. Other ingestion paths are not officially supported by Elastic.
+Elastic provides technical support for EDOT Language SDKs according to Elastic's [Support Policy](https://www.elastic.co/support_policy). EDOT SDKs are meant to be used in combination with the [{{agent}}](elastic-agent://reference/edot-collector/index.md) or the [{{motlp}}](/reference/managed-inputs/managed-otlp-endpoint.md) to ingest data into Elastic solutions from the EDOT SDKs. Other ingestion paths are not officially supported by Elastic.
 
 Using EDOT SDKs directly with {{product.apm-server}}'s OpenTelemetry intake endpoint is not supported.  
 While some data might ingest, Elastic doesn't guarantee:

--- a/docs/reference/edot-sdks/index.md
+++ b/docs/reference/edot-sdks/index.md
@@ -1,6 +1,6 @@
 ---
-navigation_title: EDOT SDKs
-description: An overview of the features available in the Elastic Distribution of OpenTelemetry (EDOT) SDKs for various languages.
+navigation_title: Elastic OTel SDKs
+description: An overview of the features available in the Elastic OTel SDKs for various languages.
 applies_to:
   stack:
   serverless:
@@ -11,15 +11,15 @@ products:
   - id: edot-sdk
 ---
 
-# EDOT SDKs 
+# Elastic OTel SDKs
 
-The {{edot}} (EDOT) SDKs are production-ready, customized distributions of [OpenTelemetry](https://opentelemetry.io/) language SDKs, specifically optimized for seamless integration with {{product.observability}}. EDOT SDKs provide a comprehensive observability solution that automatically captures distributed traces, metrics, and logs from your applications with minimal configuration.
+The Elastic OTel SDKs are production-ready, customized distributions of [OpenTelemetry](https://opentelemetry.io/) language SDKs, specifically optimized for seamless integration with {{product.observability}}. Elastic OTel SDKs provide a comprehensive observability solution that automatically captures distributed traces, metrics, and logs from your applications with minimal configuration.
 
-While maintaining full compatibility with the OpenTelemetry specification, EDOT SDKs provide improvements and bug fixes from Elastic before they become available in contrib OpenTelemetry repositories.
+While maintaining full compatibility with the OpenTelemetry specification, Elastic OTel SDKs provide improvements and bug fixes from Elastic before they become available in contrib OpenTelemetry repositories.
 
 ## Supported languages
 
-EDOT SDKs are available for the following programming languages and platforms:
+Elastic OTel SDKs are available for the following programming languages and platforms:
 
 * [.NET](elastic-otel-dotnet://reference/edot-dotnet/index.md)
 * [Java](elastic-otel-java://reference/edot-java/index.md)
@@ -32,9 +32,9 @@ EDOT SDKs are available for the following programming languages and platforms:
 
 ## Feature overview
 
-This table provides an overview of the features available in the {{edot}} (EDOT) SDKs across different programming languages.
+This table provides an overview of the features available in the Elastic OTel SDKs across different programming languages.
 
-% The following table is automatically generated from the EDOT SDKs feature data.
+% The following table is automatically generated from the Elastic OTel SDKs feature data.
 % Automation is handled by /scripts/tools.py, which reads /docs/reference/edot-sdks/features.yml
 % and generates the table using a Jinja2 template.
 
@@ -77,24 +77,24 @@ This table provides an overview of the features available in the {{edot}} (EDOT)
 
 % end:edot-features
 
-## Support for EDOT SDKs
+## Support for Elastic OTel SDKs
 
-Elastic provides technical support for EDOT Language SDKs according to Elastic's [Support Policy](https://www.elastic.co/support_policy). EDOT SDKs are meant to be used in combination with the [EDOT Collector](elastic-agent://reference/edot-collector/index.md) or the [{{motlp}}](/reference/managed-inputs/managed-otlp-endpoint.md) to ingest data into Elastic solutions from the EDOT SDKs. Other ingestion paths are not officially supported by Elastic.
+Elastic provides technical support for Elastic OTel Language SDKs according to Elastic's [Support Policy](https://www.elastic.co/support_policy). Elastic OTel SDKs are meant to be used in combination with the [{{agent}}](elastic-agent://reference/edot-collector/index.md) or the [{{motlp}}](/reference/managed-inputs/managed-otlp-endpoint.md) to ingest data into Elastic solutions from the Elastic OTel SDKs. Other ingestion paths are not officially supported by Elastic.
 
-Using EDOT SDKs directly with {{product.apm-server}}'s OpenTelemetry intake endpoint is not supported.  
+Using Elastic OTel SDKs directly with {{product.apm-server}}'s OpenTelemetry intake endpoint is not supported.  
 While some data might ingest, Elastic doesn't guarantee:
 
 - Correctness of attributes  
-- Alignment with EDOT processing pipelines  
+- Alignment with {{edot}} processing pipelines  
 - Enrichment (service metadata, environment, runtime info, and so on)  
 - Troubleshooting coverage  
 
-If you require a supported setup, route SDK telemetry through EDOT Collector or use Managed OTel intake.
+If you require a supported setup, route SDK telemetry through {{agent}} or use Managed OTel intake.
 
 :::{warning}
-Avoid using EDOT SDKs alongside any other {{product.apm}} agent, including Elastic {{product.apm}} agents. Running multiple agents in the same application process might lead to conflicting instrumentation, duplicate telemetry, or other unexpected behavior.
+Avoid using Elastic OTel SDKs alongside any other {{product.apm}} agent, including Elastic {{product.apm}} agents. Running multiple agents in the same application process might lead to conflicting instrumentation, duplicate telemetry, or other unexpected behavior.
 :::
 
 ## License
 
-EDOT SDKs are licensed under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0).
+Elastic OTel SDKs are licensed under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0).

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -20,6 +20,10 @@ Each {{edot}} distribution is assembled with selected OpenTelemetry components a
 
 [OpenTelemetry](https://opentelemetry.io/docs/) is a vendor-neutral observability framework for collecting, processing, and exporting telemetry data. If you are new to OpenTelemetry, refer to OpenTelemetry [concepts](https://opentelemetry.io/docs/concepts/) and [components](https://opentelemetry.io/docs/concepts/components/). Refer to [{{edot}} compared to upstream OpenTelemetry](/reference/compatibility/edot-vs-upstream.md) for more information on how {{edot}} differs from upstream OpenTelemetry components.
 
+:::{note}
+**Name changes in 9.5:** The EDOT Collector is now **{{agent}}** running in OpenTelemetry mode. The {{product.edot-cf}} is now the **{{edot-cf}}**.
+:::
+
 
 ## Available OpenTelemetry distributions
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -28,13 +28,13 @@ The following {{edot}} distributions are available:
 | Distribution | Latest version | Current status |
 | ------------ | ------- | ------ |
 | [{{agent}}](elastic-agent://reference/edot-collector/index.md) | {{version.edot_collector}} | GA |
-| [Elastic OTel .NET](elastic-otel-dotnet://reference/edot-dotnet/index.md) | {{version.edot_dotnet}} | GA |
-| [Elastic OTel Java](elastic-otel-java://reference/edot-java/index.md) | {{version.edot_java}} | GA |
-| [Elastic OTel Node.js](elastic-otel-node://reference/edot-node/index.md) | {{version.edot_node}} | GA |
-| [Elastic OTel PHP](elastic-otel-php://reference/edot-php/index.md) | {{version.edot_php}} | GA |
-| [Elastic OTel Python](elastic-otel-python://reference/edot-python/index.md) | {{version.edot_python}} | GA |
-| [Elastic OTel Android](apm-agent-android://reference/edot-android/index.md) | {{version.edot_android}} | GA |
-| [Elastic OTel iOS](apm-agent-ios://reference/edot-ios/index.md) | {{version.edot_ios}} | GA |
+| [EDOT .NET](elastic-otel-dotnet://reference/edot-dotnet/index.md) | {{version.edot_dotnet}} | GA |
+| [EDOT Java](elastic-otel-java://reference/edot-java/index.md) | {{version.edot_java}} | GA |
+| [EDOT Node.js](elastic-otel-node://reference/edot-node/index.md) | {{version.edot_node}} | GA |
+| [EDOT PHP](elastic-otel-php://reference/edot-php/index.md) | {{version.edot_php}} | GA |
+| [EDOT Python](elastic-otel-python://reference/edot-python/index.md) | {{version.edot_python}} | GA |
+| [EDOT Android](apm-agent-android://reference/edot-android/index.md) | {{version.edot_android}} | GA |
+| [EDOT iOS](apm-agent-ios://reference/edot-ios/index.md) | {{version.edot_ios}} | GA |
 | [{{product.edot-cf-aws}}](edot-cloud-forwarder-aws://reference/edot-cf-aws/index.md) | {{version.edot_cf_aws}} | GA |
 | [{{product.edot-cf-azure}}](edot-cloud-forwarder-azure://reference/edot-cf-azure/index.md) | {{version.edot_cf_aws}} | Technical Preview |
 | [{{edot-cf}} for GCP](/reference/edot-cloud-forwarder/gcp/index.md) | {{version.edot_cf_gcp}} | Technical Preview |

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,6 +1,6 @@
 ---
-navigation_title: Elastic Distributions of OpenTelemetry (EDOT)
-description: Reference documentation for the Elastic Distributions of OpenTelemetry (EDOT).
+navigation_title: Elastic OpenTelemetry
+description: Reference documentation for Elastic OpenTelemetry.
 applies_to:
   stack:
   serverless:
@@ -10,36 +10,36 @@ products:
   - id: observability
 ---
 
-# Elastic Distributions of OpenTelemetry (EDOT)
+# {{edot}}
 
-Elastic Distributions of OpenTelemetry (EDOT) is an open-source ecosystem of [OpenTelemetry distributions](https://opentelemetry.io/docs/concepts/distributions/) tailored to Elastic. They include a customized OpenTelemetry Collector and several OpenTelemetry Language SDKs.
+{{edot}} is an open-source ecosystem of [OpenTelemetry distributions](https://opentelemetry.io/docs/concepts/distributions/) tailored to Elastic. They include a customized OpenTelemetry Collector and several OpenTelemetry Language SDKs.
 
 ![EDOT-Distributions](images/EDOT-SDKs-Collector.png)
 
-Each EDOT distribution is assembled with selected OpenTelemetry components and tested to ensure production readiness. This gives you a reliable, optimized OpenTelemetry experience backed by Elastic support.
+Each {{edot}} distribution is assembled with selected OpenTelemetry components and tested to ensure production readiness. This gives you a reliable, optimized OpenTelemetry experience backed by Elastic support.
 
-[OpenTelemetry](https://opentelemetry.io/docs/) is a vendor-neutral observability framework for collecting, processing, and exporting telemetry data. If you are new to OpenTelemetry, refer to OpenTelemetry [concepts](https://opentelemetry.io/docs/concepts/) and [components](https://opentelemetry.io/docs/concepts/components/). Refer to [EDOT compared to upstream OpenTelemetry](/reference/compatibility/edot-vs-upstream.md) for more information on how EDOT differs from upstream OpenTelemetry components.
+[OpenTelemetry](https://opentelemetry.io/docs/) is a vendor-neutral observability framework for collecting, processing, and exporting telemetry data. If you are new to OpenTelemetry, refer to OpenTelemetry [concepts](https://opentelemetry.io/docs/concepts/) and [components](https://opentelemetry.io/docs/concepts/components/). Refer to [{{edot}} compared to upstream OpenTelemetry](/reference/compatibility/edot-vs-upstream.md) for more information on how {{edot}} differs from upstream OpenTelemetry components.
 
 
 ## Available OpenTelemetry distributions
 
-The following Elastic OpenTelemetry distributions are available:
+The following {{edot}} distributions are available:
 
 | Distribution | Latest version | Current status |
 | ------------ | ------- | ------ |
-| [EDOT Collector](elastic-agent://reference/edot-collector/index.md) | {{version.edot_collector}} | GA |
-| [EDOT .NET](elastic-otel-dotnet://reference/edot-dotnet/index.md) | {{version.edot_dotnet}} | GA |
-| [EDOT Java](elastic-otel-java://reference/edot-java/index.md) | {{version.edot_java}} | GA |
-| [EDOT Node.js](elastic-otel-node://reference/edot-node/index.md) | {{version.edot_node}} | GA |
-| [EDOT PHP](elastic-otel-php://reference/edot-php/index.md) | {{version.edot_php}} | GA |
-| [EDOT Python](elastic-otel-python://reference/edot-python/index.md) | {{version.edot_python}} | GA |
-| [EDOT Android](apm-agent-android://reference/edot-android/index.md) | {{version.edot_android}} | GA |
-| [EDOT iOS](apm-agent-ios://reference/edot-ios/index.md) | {{version.edot_ios}} | GA |
+| [{{agent}}](elastic-agent://reference/edot-collector/index.md) | {{version.edot_collector}} | GA |
+| [Elastic OTel .NET](elastic-otel-dotnet://reference/edot-dotnet/index.md) | {{version.edot_dotnet}} | GA |
+| [Elastic OTel Java](elastic-otel-java://reference/edot-java/index.md) | {{version.edot_java}} | GA |
+| [Elastic OTel Node.js](elastic-otel-node://reference/edot-node/index.md) | {{version.edot_node}} | GA |
+| [Elastic OTel PHP](elastic-otel-php://reference/edot-php/index.md) | {{version.edot_php}} | GA |
+| [Elastic OTel Python](elastic-otel-python://reference/edot-python/index.md) | {{version.edot_python}} | GA |
+| [Elastic OTel Android](apm-agent-android://reference/edot-android/index.md) | {{version.edot_android}} | GA |
+| [Elastic OTel iOS](apm-agent-ios://reference/edot-ios/index.md) | {{version.edot_ios}} | GA |
 | [{{product.edot-cf-aws}}](edot-cloud-forwarder-aws://reference/edot-cf-aws/index.md) | {{version.edot_cf_aws}} | GA |
 | [{{product.edot-cf-azure}}](edot-cloud-forwarder-azure://reference/edot-cf-azure/index.md) | {{version.edot_cf_aws}} | Technical Preview |
 | [{{edot-cf}} for GCP](/reference/edot-cloud-forwarder/gcp/index.md) | {{version.edot_cf_gcp}} | Technical Preview |
 
-Each EDOT distribution undergoes production-grade testing before being declared Generally Available (GA). Elastic provides full support for GA releases in accordance with our [support matrix](https://www.elastic.co/support/matrix) and SLAs.
+Each {{edot}} distribution undergoes production-grade testing before being declared Generally Available (GA). Elastic provides full support for GA releases in accordance with our [support matrix](https://www.elastic.co/support/matrix) and SLAs.
 
 Technical Preview distributions receive best-effort support and are not covered under standard SLAs.
 
@@ -50,18 +50,18 @@ Pick the right [Quickstart guide](docs-content://solutions/observability/get-sta
 - [Monitoring on Kubernetes](docs-content://solutions/observability/get-started/opentelemetry/use-cases/kubernetes/index.md)
 - [LLM Observability](docs-content://solutions/observability/get-started/opentelemetry/use-cases/llms/index.md)
 
-## EDOT Demo environment
+## {{edot}} Demo environment
 
-A demo environment that showcases EDOT capabilities is available in the [opentelemetry-demo repository](https://github.com/elastic/opentelemetry-demo).
+A demo environment that showcases {{edot}} capabilities is available in the [opentelemetry-demo repository](https://github.com/elastic/opentelemetry-demo).
 
-The EDOT demo includes:
+The {{edot}} demo includes:
 
 * Sample applications instrumented with OpenTelemetry SDKs.
-* EDOT Collector configured for various scenarios. For example, Kubernetes and hosts.
+* {{agent}} configured for various scenarios. For example, Kubernetes and hosts.
 * Integration with an Elastic Stack deployment, such as {{es}} and {{kib}}.
 
 Follow the instructions in the demo repository to set up and run the demo.
 
 ## Report an issue or provide feedback
 
-To report an issue or provide feedback on EDOT, [submit a GitHub issue](https://github.com/elastic/opentelemetry/issues/new/choose).
+To report an issue or provide feedback on {{edot}}, [submit a GitHub issue](https://github.com/elastic/opentelemetry/issues/new/choose).

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -21,7 +21,8 @@ Each {{edot}} distribution is assembled with selected OpenTelemetry components a
 [OpenTelemetry](https://opentelemetry.io/docs/) is a vendor-neutral observability framework for collecting, processing, and exporting telemetry data. If you are new to OpenTelemetry, refer to OpenTelemetry [concepts](https://opentelemetry.io/docs/concepts/) and [components](https://opentelemetry.io/docs/concepts/components/). Refer to [{{edot}} compared to upstream OpenTelemetry](/reference/compatibility/edot-vs-upstream.md) for more information on how {{edot}} differs from upstream OpenTelemetry components.
 
 :::{note}
-**Name changes in 9.5:** The EDOT Collector is now **{{agent}}** running in OpenTelemetry mode. The {{product.edot-cf}} is now the **{{edot-cf}}**.
+:applies_to: stack: ga 9.5+
+In previous versions, the **EDOT Collector** was a standalone product. From this version onwards, this OpenTelemetry collector capability is built into **{{agent}}**.
 :::
 
 

--- a/docs/reference/managed-inputs/index.md
+++ b/docs/reference/managed-inputs/index.md
@@ -20,5 +20,5 @@ Managed inputs are the recommended ingestion path for {{ecloud}}. The following 
 
 | Input | Protocol | Use it to |
 | --- | --- | --- |
-| [Managed OTLP Endpoint](managed-otlp-endpoint.md) | OpenTelemetry Protocol (OTLP) | Ingest OpenTelemetry logs, metrics, and traces from EDOT collectors and SDKs, the EDOT Cloud Forwarder, upstream OpenTelemetry collectors and SDKs, or any OTLP-compliant shipper. |
+| [Managed OTLP Endpoint](managed-otlp-endpoint.md) | OpenTelemetry Protocol (OTLP) | Ingest OpenTelemetry logs, metrics, and traces from {{agent}} collectors and Elastic OTel SDKs, {{edot-cf}}, upstream OpenTelemetry collectors and SDKs, or any OTLP-compliant shipper. |
 | [Managed Prometheus Remote Write endpoint](prometheus-remote-write.md) | Prometheus Remote Write v1 (PRW) | Ingest Prometheus metrics into {{es}} time series data streams. |

--- a/docs/reference/managed-inputs/index.md
+++ b/docs/reference/managed-inputs/index.md
@@ -20,5 +20,5 @@ Managed inputs are the recommended ingestion path for {{ecloud}}. The following 
 
 | Input | Protocol | Use it to |
 | --- | --- | --- |
-| [Managed OTLP Endpoint](managed-otlp-endpoint.md) | OpenTelemetry Protocol (OTLP) | Ingest OpenTelemetry logs, metrics, and traces from {{agent}} collectors and Elastic OTel SDKs, {{edot-cf}}, upstream OpenTelemetry collectors and SDKs, or any OTLP-compliant shipper. |
+| [Managed OTLP Endpoint](managed-otlp-endpoint.md) | OpenTelemetry Protocol (OTLP) | Ingest OpenTelemetry logs, metrics, and traces from {{agent}} collectors and EDOT SDKs, {{edot-cf}}, upstream OpenTelemetry collectors and SDKs, or any OTLP-compliant shipper. |
 | [Managed Prometheus Remote Write endpoint](prometheus-remote-write.md) | Prometheus Remote Write v1 (PRW) | Ingest Prometheus metrics into {{es}} time series data streams. |

--- a/docs/reference/managed-inputs/managed-otlp-endpoint.md
+++ b/docs/reference/managed-inputs/managed-otlp-endpoint.md
@@ -20,7 +20,7 @@ The {{motlp}} allows you to send OpenTelemetry data directly to {{ecloud}} using
 The endpoint provides a resilient ingestion layer that integrates with serverless autoscaling and offloads ingestion processing from {{ech}} clusters.
 
 :::{important}
-The {{motlp}} endpoint is not available for Elastic [self-managed](docs-content://deploy-manage/deploy/self-managed.md), [ECE](docs-content://deploy-manage/deploy/cloud-enterprise.md), or [ECK](docs-content://deploy-manage/deploy/cloud-on-k8s.md) clusters. To send OTLP data to any of these cluster types, deploy and expose an OTLP-compatible endpoint using the [EDOT Collector as a gateway](elastic-agent://reference/edot-collector/modes.md#edot-collector-as-gateway).
+The {{motlp}} endpoint is not available for Elastic [self-managed](docs-content://deploy-manage/deploy/self-managed.md), [ECE](docs-content://deploy-manage/deploy/cloud-enterprise.md), or [ECK](docs-content://deploy-manage/deploy/cloud-on-k8s.md) clusters. To send OTLP data to any of these cluster types, deploy and expose an OTLP-compatible endpoint using the [{{agent}} as a gateway](elastic-agent://reference/edot-collector/modes.md#edot-collector-as-gateway).
 :::
 
 ## Prerequisites
@@ -29,9 +29,9 @@ To use the {{ecloud}} {{motlp}} you need the following:
 
 - An {{serverless-full}} project or an {{ech}} (ECH) deployment.
 - An OTLP-compliant shipper capable of forwarding logs, metrics, or traces in OTLP format. This can include:
-  - [OpenTelemetry Collector](elastic-agent://reference/edot-collector/index.md) (EDOT, Contrib, or other distributions)
-  - [OpenTelemetry SDKs](/reference/edot-sdks/index.md) (EDOT, upstream, or other distributions)
-  - [EDOT Cloud Forwarder](/reference/edot-cloud-forwarder/index.md)
+  - [OpenTelemetry Collector](elastic-agent://reference/edot-collector/index.md) ({{edot}}, Contrib, or other distributions)
+  - [OpenTelemetry SDKs](/reference/edot-sdks/index.md) ({{edot}}, upstream, or other distributions)
+  - [{{edot-cf}}](/reference/edot-cloud-forwarder/index.md)
   - Any other forwarder that supports the OTLP protocol.
 
 You don't need APM Server when ingesting data through the Managed OTLP Endpoint. The APM integration (`.apm` endpoint) is a legacy ingest path that translates OTLP telemetry to ECS, whereas {{motlp}} natively ingests OTLP data.
@@ -169,7 +169,7 @@ The following limitations apply when using the {{motlp}}:
 * Universal Profiling is not available.
 * Only supports histograms with delta temporality. Cumulative histograms are dropped.
 * Latency distributions based on histogram values have limited precision due to the fixed boundaries of explicit bucket histograms.
-* Tail-based sampling (TBS) is not available. The {{motlp}} does not provide centralized hosted sampling. If you need tail-based sampling, configure it on the edge using the [Tail Sampling Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor) in your EDOT or OpenTelemetry Collector before sending data to the endpoint.
+* Tail-based sampling (TBS) is not available. The {{motlp}} does not provide centralized hosted sampling. If you need tail-based sampling, configure it on the edge using the [Tail Sampling Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor) in your {{edot}} or OpenTelemetry Collector before sending data to the endpoint.
 * In {{ech}} deployments:
   * [IP filters](docs-content://deploy-manage/security/ip-filtering-cloud.md) do not apply to the managed endpoint.
   * The endpoint is not available over a [private connection](docs-content://deploy-manage/security/private-connectivity.md). When private connectivity is configured, the public managed endpoint is still available.

--- a/docs/reference/managed-inputs/troubleshooting.md
+++ b/docs/reference/managed-inputs/troubleshooting.md
@@ -26,7 +26,7 @@ The following sections provide troubleshooting information for the Elastic Cloud
 
 ### Resolution
 
-Set up an EDOT collector using one of the quickstart guides:
+Set up an {{agent}} using one of the quickstart guides:
 
 - [Kubernetes Quickstart](https://www.elastic.co/docs/solutions/observability/get-started/opentelemetry/quickstart/serverless/k8s)
 - [Hosts & VMs Quickstart](https://www.elastic.co/docs/solutions/observability/get-started/opentelemetry/quickstart/serverless/hosts_vms)
@@ -72,7 +72,7 @@ Your project might be hitting ingest rate limits. Refer to the dedicated [429 er
 
 ### Resolution
 
-Reduce the payload size sent by your collector by lowering batching limits. In the EDOT Collector (and upstream or contrib collectors), you can reduce the maximum batch size (in uncompressed bytes) so each request stays smaller.
+Reduce the payload size sent by your collector by lowering batching limits. In the {{agent}} (and upstream or contrib collectors), you can reduce the maximum batch size (in uncompressed bytes) so each request stays smaller.
 
 For configuration guidance and the recommended batching settings for sending data to the Elastic Cloud Managed OTLP Endpoint, refer to [Batching configuration for contrib OpenTelemetry Collector](elastic-agent://reference/edot-collector/config/default-config-standalone.md#batching-configuration-for-contrib-opentelemetry-collector).
 
@@ -145,4 +145,4 @@ For more information, refer to [AutoOps](docs-content://deploy-manage/monitor/au
 
 Help improve the Elastic Cloud Managed OTLP Endpoint by sending us feedback in our [discussion forum](https://discuss.elastic.co/c/apm) or [community Slack](https://elasticstack.slack.com/signup#/domain-signup).
 
-For EDOT collector feedback, open an issue in the [elastic-agent repository](https://github.com/elastic/elastic-agent/issues).
+For {{agent}} feedback, open an issue in the [elastic-agent repository](https://github.com/elastic/elastic-agent/issues).


### PR DESCRIPTION
## What does this PR do?

Renames all user-facing prose across the opentelemetry docs hub per the 9.5 product-naming decision ([elastic/docs-content-internal#1242](https://github.com/elastic/docs-content-internal/issues/1242)):

| Old | New |
|-----|-----|
| EDOT Collector | `{{agent}}` → Elastic Agent |
| EDOT Cloud Forwarder | `{{edot-cf}}` → Elastic Cloud Forwarder |
| EDOT (generic brand) | `{{edot}}` → Elastic OpenTelemetry |

Also updates `docs/docset.yml`: flips `edot` and `edot-cf` sub values, adds `agent` sub, renames the project title.

22 files changed: `compatibility/`, `architecture/`, `edot-cloud-forwarder/`, `managed-inputs/`, and the hub pages (`index.md`, `central-configuration.md`, `data-streams.md`, `edot-sdks/index.md`).

## Why is it important?

This is the hub repo for all EDOT/OTel reference content. It needs to consistently reflect the new names before the 9.5 GA cutover.

## How to test

Build docs locally with `docs-builder` and verify:
- No "EDOT" prose in rendered output (excluding the image filenames)
- `{{edot}}` renders as "Elastic OpenTelemetry", `{{agent}}` as "Elastic Agent", `{{edot-cf}}` as "Elastic Cloud Forwarder"

## Notes

- **Do not merge yet** — merges in coordinated window with `elastic-agent`, `docs-content`, and `docs-builder` PRs on 9.5 GA (July 28, 2026)
- Related: elastic/elastic-agent#15639
- Part of: elastic/docs-content-internal#1242