### PR TITLE
Update Serverless mOTLP endpoint UI label from Ingest to OpenTelemetry

### DIFF
--- a/docs/reference/_snippets/find-motlp-endpoint.md
+++ b/docs/reference/_snippets/find-motlp-endpoint.md
@@ -6,7 +6,7 @@ To retrieve your {{motlp}} endpoint and generate an API key to authenticate your
 
 1. Log in to the {{ecloud}} Console.
 2. Find your project and select **Manage**.
-3. In the **Application endpoints, cluster and component IDs** section, select **Ingest**.
+3. In the **Application endpoints, cluster and component IDs** section, select **OpenTelemetry**.
 4. Copy the endpoint value.
 
 :::{tip}


### PR DESCRIPTION
The Serverless steps for finding the Managed OTLP endpoint referenced an outdated UI label. In the **Application endpoints, cluster and component IDs** section, the entry is now labeled **OpenTelemetry** instead of **Ingest**. This updates `docs/reference/_snippets/find-motlp-endpoint.md` accordingly, which is included in the Managed OTLP Endpoint reference page.

Resolves https://github.com/elastic/docs-content/issues/7532

Made with Cursor