### PR TITLE
Pass DOCS_LITELLM_API_KEY to agentic workflow callers via secrets: inherit

### DIFF
--- a/.github/workflows/docs-applies-to-sweep.yml
+++ b/.github/workflows/docs-applies-to-sweep.yml
@@ -29,7 +29,6 @@ on:
 
 permissions:
   actions: read
-  copilot-requests: write
   contents: read
   discussions: write
   issues: write
@@ -45,3 +44,4 @@ jobs:
       scope-mode: ${{ inputs.scope-mode }}
       target-batch-size: ${{ inputs.target-batch-size }}
       max-per-fix-issue: ${{ inputs.max-per-fix-issue }}
+    secrets: inherit

--- a/.github/workflows/docs-coherence-sweep.yml
+++ b/.github/workflows/docs-coherence-sweep.yml
@@ -29,7 +29,6 @@ on:
 
 permissions:
   actions: read
-  copilot-requests: write
   contents: read
   discussions: write
   issues: write
@@ -45,3 +44,4 @@ jobs:
       scope-mode: ${{ inputs.scope-mode }}
       target-batch-size: ${{ inputs.target-batch-size }}
       max-per-fix-issue: ${{ inputs.max-per-fix-issue }}
+    secrets: inherit

--- a/.github/workflows/docs-frontmatter-sweep.yml
+++ b/.github/workflows/docs-frontmatter-sweep.yml
@@ -29,7 +29,6 @@ on:
 
 permissions:
   actions: read
-  copilot-requests: write
   contents: read
   discussions: write
   issues: write
@@ -45,3 +44,4 @@ jobs:
       scope-mode: ${{ inputs.scope-mode }}
       target-batch-size: ${{ inputs.target-batch-size }}
       max-per-fix-issue: ${{ inputs.max-per-fix-issue }}
+    secrets: inherit

--- a/.github/workflows/docs-openings-sweep.yml
+++ b/.github/workflows/docs-openings-sweep.yml
@@ -29,7 +29,6 @@ on:
 
 permissions:
   actions: read
-  copilot-requests: write
   contents: read
   discussions: write
   issues: write
@@ -45,3 +44,4 @@ jobs:
       scope-mode: ${{ inputs.scope-mode }}
       target-batch-size: ${{ inputs.target-batch-size }}
       max-per-fix-issue: ${{ inputs.max-per-fix-issue }}
+    secrets: inherit

--- a/.github/workflows/docs-staleness-sweep.yml
+++ b/.github/workflows/docs-staleness-sweep.yml
@@ -33,7 +33,6 @@ on:
 
 permissions:
   actions: read
-  copilot-requests: write
   contents: read
   discussions: write
   issues: write
@@ -50,3 +49,4 @@ jobs:
       target-batch-size: ${{ inputs.target-batch-size }}
       max-per-fix-issue: ${{ inputs.max-per-fix-issue }}
       stale-content-months: ${{ inputs.stale-content-months }}
+    secrets: inherit

--- a/.github/workflows/docs-style-sweep.yml
+++ b/.github/workflows/docs-style-sweep.yml
@@ -29,7 +29,6 @@ on:
 
 permissions:
   actions: read
-  copilot-requests: write
   contents: read
   discussions: write
   issues: write
@@ -45,3 +44,4 @@ jobs:
       scope-mode: ${{ inputs.scope-mode }}
       target-batch-size: ${{ inputs.target-batch-size }}
       max-per-fix-issue: ${{ inputs.max-per-fix-issue }}
+    secrets: inherit

--- a/.github/workflows/docs-typos-sweep.yml
+++ b/.github/workflows/docs-typos-sweep.yml
@@ -33,7 +33,6 @@ on:
 
 permissions:
   actions: read
-  copilot-requests: write
   contents: read
   discussions: write
   issues: write
@@ -50,3 +49,4 @@ jobs:
       target-batch-size: ${{ inputs.target-batch-size }}
       max-per-fix-issue: ${{ inputs.max-per-fix-issue }}
       codespell-args: ${{ inputs.codespell-args }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

- GitHub Actions does **not** automatically forward secrets to reusable workflows called via `uses:`/`workflow_call`. Without explicit passthrough, `ANTHROPIC_API_KEY` (mapped from `secrets.DOCS_LITELLM_API_KEY`) is empty and the agentic workflows fail with "None of the following secrets are set: ANTHROPIC_API_KEY".
- Added `secrets: inherit` to each of the 7 docs-sweep jobs so the calling workflow passes all its secrets down to the reusable workflow.
- Also removed the now-unused `copilot-requests: write` permission from each workflow's `permissions:` block (the Copilot engine was replaced by the Claude/LiteLLM engine).

## Files changed

`docs-applies-to-sweep.yml`, `docs-coherence-sweep.yml`, `docs-frontmatter-sweep.yml`, `docs-openings-sweep.yml`, `docs-staleness-sweep.yml`, `docs-style-sweep.yml`, `docs-typos-sweep.yml`

## Test plan

- [ ] Trigger one of the sweep workflows manually after merge and confirm it no longer errors on missing `ANTHROPIC_API_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)