### PR TITLE
Add experimental docs agent invocation

### DIFF
--- a/.github/workflows/docs-agent-experimental.yml
+++ b/.github/workflows/docs-agent-experimental.yml
@@ -1,0 +1,29 @@
+name: Docs Agent Experimental
+
+on:
+  issues:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number to process
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+  discussions: write
+  issues: write
+  pull-requests: write
+  copilot-requests: write
+
+jobs:
+  run:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.label.name == 'docs-agent'
+    uses: elastic/docs-actions/.github/workflows/docs-agent-experimental.lock.yml@v1
+    with:
+      issue_number: ${{ github.event.issue.number || inputs.issue_number }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

Add the repository invocation workflow for `docs-agent-experimental`.

The caller runs when an issue receives the `docs-agent` label and supports manual testing with an issue number. It grants the reusable workflow the established Agentic Workflow permission set and inherits repository secrets for the Copilot engine and authoring-skill installation.

## Dependency and rollout

- Depends on elastic/docs-actions#262.
- The `elastic/docs-actions` `v1` tag must include that change before this caller is merged or run.
- The `docs-agent`, `docs-agent-declined`, and `automation` labels do not currently exist in this repository and must be created before activation.
- The central workflow still uses staged safe outputs, so initial runs create previews rather than comments, labels, or pull requests.

## Validation

- `actionlint` passes with only its outdated `copilot-requests` permission diagnostic ignored; this permission is already used by the repository's existing Agentic Workflow callers.
- `git diff --check`
