### PR TITLE
Fix docs agent actions permission

### DIFF
--- a/.github/workflows/docs-agent-experimental.yml
+++ b/.github/workflows/docs-agent-experimental.yml
@@ -11,7 +11,7 @@ on:
         type: string
 
 permissions:
-  actions: read
+  actions: write
   contents: read
   discussions: write
   issues: write


### PR DESCRIPTION
## Summary

Grant `actions: write` to the `docs-agent-experimental` reusable-workflow caller.

The compiled workflow generates a `conclusion` job that requires this permission. With only `actions: read`, GitHub rejects the invocation before any job starts. The AI agent job remains read-only, and all repository writes remain routed through staged safe outputs.

## Validation

- `actionlint` passes with only its outdated `copilot-requests` permission diagnostic ignored
- `git diff --check`

This fixes the workflow validation error reported after #650 merged.

Staged verification run on issue #648: https://github.com/elastic/opentelemetry/actions/runs/30905136689
