### PR TITLE
Allow docs agent safe outputs to create draft branches

### DIFF
--- a/.github/workflows/docs-agent-experimental.yml
+++ b/.github/workflows/docs-agent-experimental.yml
@@ -12,7 +12,7 @@ on:
 
 permissions:
   actions: write
-  contents: read
+  contents: write
   discussions: write
   issues: write
   pull-requests: write


### PR DESCRIPTION
Grants contents write to the reusable docs-agent workflow. The main agent remains read-only in the central workflow; this caller permission is required only by the compiler-generated safe-output jobs when they create the draft branch and pull request.

## Rollout

Companion change: elastic/docs-actions#263. Merge this caller permission change before the docs-actions v1 tag advances to that change.

## Validation

Validated with actionlint and git diff --check.