### PR TITLE
Fix duplicate Managed Vercel endpoint entry

### DIFF
--- a/docs/reference/managed-inputs/index.md
+++ b/docs/reference/managed-inputs/index.md
@@ -24,7 +24,6 @@ Managed inputs are the recommended ingestion path for {{ecloud}}. The following 
 | [Managed Prometheus Remote Write endpoint](prometheus-remote-write.md) | Prometheus Remote Write v1 (PRW) | Ingest Prometheus metrics into {{es}} time series data streams. |
 | [Managed {{es}} _bulk endpoint](elasticsearch-bulk.md) | {{es}} `_bulk` API | Ingest data from `_bulk`-based shippers such as {{product.beats}}, {{product.elastic-agent}}, {{product.logstash}}, and other {{es}}-compatible shippers. |
 | [Managed Vercel endpoint](integration-docs://reference/vercel.md) | JSON or NDJSON | Ingest Vercel logs, audit logs, Web Analytics, and Speed Insights to {{es}} |
-| [Managed Vercel endpoint](integration-docs://reference/vercel.md) | JSON or NDJSON | Ingest Vercel logs, audit logs, Web Analytics, and Speed Insights to {{es}}. |
 | [Managed Supabase endpoint](integration-docs://reference/supabase.md) | OpenTelemetry Protocol (OTLP) | Ingest Supabase logs using the OpenTelemetry. |
 
 


### PR DESCRIPTION
Removed duplicate entry for Managed Vercel endpoint in the documentation.