### PR TITLE
Update histogram temporality limitation on mOTLP page

### DIFF
--- a/docs/reference/managed-inputs/managed-otlp-endpoint.md
+++ b/docs/reference/managed-inputs/managed-otlp-endpoint.md
@@ -141,7 +141,7 @@ A successful response from the {{motlp}} means your data was durably accepted fo
 The following limitations apply when using the {{motlp}}:
 
 * Universal Profiling is not available.
-* Only supports histograms with delta temporality. Cumulative histograms are dropped.
+* For supported metric temporalities for histograms and counters, refer to [Metric temporality](docs-content://manage-data/ingest/otlp-endpoint.md#metric-temporality).
 * Latency distributions based on histogram values have limited precision due to the fixed boundaries of explicit bucket histograms.
 * Tail-based sampling (TBS) is not available. The {{motlp}} does not provide centralized hosted sampling. If you need tail-based sampling, configure it on the edge using the [Tail Sampling Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor) in your {{edot}} or OpenTelemetry Collector before sending data to the endpoint.
 * For {{ech}} network limitations that apply to all managed inputs, refer to [{{ech}} limitations](authentication-delivery-and-failure-handling.md#ech-limitations).


### PR DESCRIPTION
## Summary

- Removes the stale limitation "Only supports histograms with delta temporality. Cumulative histograms are dropped" from the managed OTLP endpoint page. It is no longer accurate as of stack 9.5+ / serverless.
- Replaces it with a cross-reference to the Metric temporality docs, which are now the authoritative source for temporality support details.

Follows up on #653, which updated `docs/reference/compatibility/limitations.md` but missed this page.