### PR TITLE
Simplify instructions for finding the Prometheus endpoint

### DIFF
--- a/docs/reference/managed-inputs/prometheus-remote-write.md
+++ b/docs/reference/managed-inputs/prometheus-remote-write.md
@@ -56,7 +56,7 @@ To find `<prometheus-endpoint>`:
 1. Log in to the {{ecloud}} Console.
 2. Find your project and select **Manage**.
 3. In the **Application endpoints, cluster and component IDs** section, select **Prometheus**.
-4. Copy the **Prometheus** endpoint value, which looks similar to `https://<project>.ingest.<region>.<csp>.elastic.cloud/api/v1/write`
+4. Copy the **Prometheus** endpoint value.
 
 :::::
 


### PR DESCRIPTION
The namespace of the Prometheus endpoint will soon be modified when https://github.com/elastic/kibana/pull/283061 is merged. This PR removes the reference to a specific pattern in the endpoint path.