### PR TITLE
docs: mark ECH as supported for cumulative histogram temporality via mOTLP

### DIFF
--- a/docs/reference/compatibility/limitations.md
+++ b/docs/reference/compatibility/limitations.md
@@ -72,6 +72,8 @@ Temporality support for histogram and counter metrics depends on the ingestion p
 ```{applies_to}
 stack: ga 9.5+
 serverless: ga
+deployment:
+  ech: ga
 ```
 
 When you send data using the [{{motlp}}](/reference/managed-inputs/managed-otlp-endpoint.md), both [`delta` and `cumulative` temporality](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#temporality) are supported for [`Histogram`](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#histogram) and counter metrics.


### PR DESCRIPTION
## Summary

Marks ECH as a supported deployment type in the mOTLP histogram temporality section of the limitations doc.

The ECH native OTLP metrics rollout is now complete in staging and production (elastic/serverless-gitops#165649, elastic/serverless-gitops#165670). mOTLP on ECH now routes metrics through the native ES OTLP endpoint, which supports both `delta` and `cumulative` temporality for histograms. Adding `deployment.ech: ga` to the `applies_to` block reflects this.

Closes elastic/hosted-otel-collector#3683 (docs task).

## Test plan

- [ ] Verify the `applies_to` block renders correctly in the docs preview